### PR TITLE
仮のログイン後ダッシュボードの追加

### DIFF
--- a/app/controllers/dash_boards_controller.rb
+++ b/app/controllers/dash_boards_controller.rb
@@ -1,0 +1,4 @@
+class DashBoardsController < ApplicationController
+  def index
+  end
+end

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -1,0 +1,35 @@
+<header class="navbar bg-base-100 shadow px-6">
+  <div class="flex-1">
+    <a class="text-xl font-bold">ifthen maker</a>
+  </div>
+  <div class="flex-none gap-2">
+  </div>
+</header>
+<main class="hero min-h-[70vh] bg-base-200">
+  <div class="hero-content text-center">
+    <div class="max-w-md">
+      <h1 class="text-4xl font-bold">ダッシュボード</h1>
+
+      <div class="card bg-base-100 shadow my-6">
+        <div class="card bg-base-100 shadow-lg border border-base-300">習慣</div>
+        <div class="card bg-base-100 shadow-lg border border-base-300">習慣</div>
+        <div class="card bg-base-100 shadow-lg border border-base-300">習慣</div>
+      </div>
+
+      <div class="mt-12 flex flex-col gap-3">
+        <a href="#" class="btn btn-primary"> 新しく習慣を作成する</a>
+      </div>
+
+    </div>
+  </div>
+</main>
+<footer class="footer footer-center p-6 text-base-content bg-base-100 shadow">
+  <div>
+    <div class="flex gap-4 bg-configtest">
+      <a href="#" class="link link-hover">ホーム</a>
+      <a href="#" class="link link-hover">習慣一覧</a>
+      <a href="#" class="link link-hover">メモ一覧</a>
+      <a href="#" class="link link-hover">振り返り一覧</a>
+    </div>
+  </div>
+</footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root "pages#landing_page"
-  resources :dash_boards, only: [:index]
+  resources :dash_boards, only: [ :index ]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root "pages#landing_page"
+  resources :dash_boards, only: [:index]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## 概要
ログイン後に遷移するダッシュボードの画面の作成

Close #18 

## 実装内容
### 予定していた作業
- [x] ログイン後の画面の作成
  - [x] ログイン後画面用にdash_boardsコントローラー作成
  - [x] ルーティング設定(dash_boards#indexとする)
  - [x] 仮としてログイン後の画面のビューを作成しておく


## 動作確認
- [x] /dashboardsで作成した画面が表示されること
