### PR TITLE
ユーザー新規登録機能実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,8 @@
+class UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,5 +4,23 @@ class UsersController < ApplicationController
   end
 
   def create
+    @user = User.new(user_params)
+
+    if @user.save
+      # 後でSorceryの自動ログイン処理を入れるauto_login?
+      redirect_to dash_boards_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(
+      :email,
+      :password,
+      :password_confirmation
+    )
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
       # 後でSorceryの自動ログイン処理を入れるauto_login?
       redirect_to dash_boards_path
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/views/pages/landing_page.html.erb
+++ b/app/views/pages/landing_page.html.erb
@@ -1,9 +1,9 @@
 <header class="navbar bg-base-100 shadow px-6">
   <div class="flex-1">
-    <a class="text-xl font-bold">ifthen maker</a>
+    <a href= <%= root_path %> class="text-xl font-bold">ifthen maker</a>
   </div>
   <div class="flex-none gap-2">
-    <a href="#" class="btn btn-ghost">新規登録</a>
+    <a href=<%= new_user_path %> class="btn btn-ghost">新規登録</a>
     <a href="#" class="btn btn-outline btn-primary">ログイン</a>
   </div>
 </header>
@@ -25,7 +25,7 @@
       </div>
 
       <div class="mt-6 flex flex-col gap-3">
-        <a href="#" class="btn btn-primary">
+        <a href=<%= new_user_path %> class="btn btn-primary">
           新規登録
         </a>
         <a href="#" class="btn btn-outline">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,76 @@
+<header class="navbar bg-base-100 shadow px-6">
+  <div class="flex-1">
+    <a class="text-xl font-bold">ifthen maker</a>
+  </div>
+  <div class="flex-none gap-2">
+  </div>
+</header>
+<main class="hero min-h-[70vh] bg-base-200">
+  <div class="hero-content text-center">
+    <div class="card w-full max-w-md shadow-xl bg-base-100">
+    <div class="card-body">
+      <h1 class="text-4xl font-bold text-center mb-4">
+        新規登録
+      </h1>
+
+
+      <%= form_with model: @user, local: true, class: "space-y-4" do |f| %>
+
+        <!-- Email -->
+        <div class="form-control">
+          <%= f.label :email, "メールアドレス", class: "label" %>
+          <%= f.email_field :email,
+                class: "input input-bordered w-full",
+                placeholder: "example@example.com" %>
+          <% if @user.errors[:email].any? %>
+            <p class="text-error text-sm mt-1">
+              <%= @user.errors[:email].first %>
+            </p>
+          <% end %>
+        </div>
+
+        <!-- Password -->
+        <div class="form-control">
+          <%= f.label :password, "パスワード", class: "label" %>
+          <%= f.password_field :password,
+                class: "input input-bordered w-full",
+                placeholder: "3文字以上" %>
+          <% if @user.errors[:password].any? %>
+            <p class="text-error text-sm mt-1">
+              <%= @user.errors[:password].first %>
+            </p>
+          <% end %>
+        </div>
+
+        <!-- Password confirmation -->
+        <div class="form-control">
+          <%= f.label :password_confirmation, "パスワード（確認）", class: "label" %>
+          <%= f.password_field :password_confirmation,
+                class: "input input-bordered w-full" %>
+          <% if @user.errors[:password_confirmation].any? %>
+            <p class="text-error text-sm mt-1">
+              <%= @user.errors[:password_confirmation].first %>
+            </p>
+          <% end %>
+        </div>
+
+        <!-- Submit -->
+        <div class="form-control mt-6">
+          <%= f.submit "登録する", class: "btn btn-primary w-full" %>
+        </div>
+
+      <% end %>
+    </div>
+  </div>
+  </div>
+</main>
+<footer class="footer footer-center p-6 text-base-content bg-base-100 shadow">
+  <div>
+    <div class="flex gap-4 bg-configtest">
+      <a href="#" class="link link-hover">ホーム</a>
+      <a href="#" class="link link-hover">習慣一覧</a>
+      <a href="#" class="link link-hover">メモ一覧</a>
+      <a href="#" class="link link-hover">振り返り一覧</a>
+    </div>
+  </div>
+</footer>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,6 @@
 <header class="navbar bg-base-100 shadow px-6">
   <div class="flex-1">
-    <a class="text-xl font-bold">ifthen maker</a>
+    <a href= <%= root_path %> class="text-xl font-bold">ifthen maker</a>
   </div>
   <div class="flex-none gap-2">
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root "pages#landing_page"
   resources :dash_boards, only: [ :index ]
+  resources :users, only: [ :new, :create ]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Users", type: :request do
         expect {
           post users_path, params: {
             user: {
+              
               email: "",
               password: "password",
               password_confirmation: "password"
@@ -32,7 +33,7 @@ RSpec.describe "Users", type: :request do
           }
         }.not_to change(User, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("新規登録")
       end
     end

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Users", type: :request do
         expect {
           post users_path, params: {
             user: {
-              
+
               email: "",
               password: "password",
               password_confirmation: "password"

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  describe "POST /users系をテストする" do
+    context "正常系" do
+      it "ユーザー登録に成功でUserの数が増える,成功ダッシュボードに遷移するリダイレクトが帰ってくる" do
+        expect {
+          post users_path, params: {
+            user: {
+              email: "test@example.com",
+              password: "password",
+              password_confirmation: "password"
+            }
+          }
+        }.to change(User, :count).by(1)
+
+        expect(response).to redirect_to(dash_boards_path)
+        follow_redirect!
+
+        expect(response.body).to include("ダッシュボード")
+      end
+    end
+          context "異常系" do
+      it "バリデーションエラー時は数が増えず、新規登録画面を再表示する" do
+        expect {
+          post users_path, params: {
+            user: {
+              email: "",
+              password: "password",
+              password_confirmation: "password"
+            }
+          }
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("新規登録")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- ユーザーの新規登録機能の実装
- 新規登録画面の作成
- user#newと#createで実装

Close #12 

## 実装内容
### 予定していた作業
  - [x] 新規登録機能のルーティング設定
  - [x] users#new(新規作成画面)
  - [x] users#create(新規作成処理)

- [x] users_controller作成 
  - [x]  #newのアクション編集
- [x] users#newとして新規登録機能のビューファイル作成
  - [x] フォームを作成
    - [x] emailの項目
    - [x] passwordの項目
    - [x] password_confirmationの項目
- [x] user_controllerを#create編集して新規登録処理の作成
  - [x] ストロングパラメータにする
  - [x] 登録後はログイン後の画面に行く

- [x] 新規登録画面への動線の追加(LPのリンクを編集)

- [x] テストの作成



### 予定外だが実施した作業
- [x] unprocessable_entityをunprocessable_contentに変更（将来的にrackが対応しなくなるらしいため）

## 動作確認
- [x] 新規ユーザーが登録できる
  ~- [x] 新規登録画面が表示できる~ (まだ画面が完全ではないのでsystemspecは別イシューとして行う？)
  - [x] 新規登録画面からDBにusersが作成される
- [x] 新規ユーザー登録失敗ではそのままの画面にする
- [x] 成功したらログイン後の画面へ行く
  - [x] リダイレクト指示が来ている
  - [x] それによる遷移先が"ダッシュボード"


## 備考
 きちんとしたフラッシュメッセージ機能は後ほどログイン、ログアウトの作成後にまとめてみていきたい。