### PR TITLE
Feat/フラッシュメッセージを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,6 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authenticated
-    redirect_to login_path
+    redirect_to login_path, alert: "ログインしてください"
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -16,7 +16,7 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
-    redirect_to root_path, status: :see_other ,notice: "ログアウトしました"
+    redirect_to root_path, status: :see_other, notice: "ログアウトしました"
   end
 
   private

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,15 +7,16 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_to dash_boards_path
+      redirect_to dash_boards_path, notice: "ログインが成功しました"
     else
+      flash.now[:alert] = "ログインが失敗しました"
       render :new, status: :unprocessable_content
     end
   end
 
   def destroy
     logout
-    redirect_to root_path, status: :see_other
+    redirect_to root_path, status: :see_other ,notice: "ログアウトしました"
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,8 +9,9 @@ class UsersController < ApplicationController
 
     if @user.save
       auto_login(@user)
-      redirect_to dash_boards_path
+      redirect_to dash_boards_path, notice: "ユーザー登録が成功しました"
     else
+      flash.now[:alert] = "ユーザー登録が失敗しました"
       render :new, status: :unprocessable_content
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+
+  def flash_class(type)
+    case type.to_sym
+    when :notice then "alert-success"
+    when :alert  then "alert-error"
+    else "alert-info"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,4 @@
 module ApplicationHelper
-
   def flash_class(type)
     case type.to_sym
     when :notice then "alert-success"

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -3,7 +3,13 @@
     <a class="text-xl font-bold">ifthen maker</a>
   </div>
   <div class="flex-none gap-2">
-    <%= button_to "ログアウト", logout_path, method: :delete %>
+    <%= link_to "ログアウト",
+            logout_path,
+            data: {
+              turbo_method: :delete,
+              turbo_confirm: "ログアウトしますか？"
+            },
+            class: "btn btn-outline btn-error" %>
   </div>
 </header>
 <main class="hero min-h-[70vh] bg-base-200">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,11 @@
   </head>
 
   <body>
+    <% flash.each do |type, message| %>
+      <div class="alert <%= flash_class(type) %> mb-4">
+        <span><%= message %></span>
+      </div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/spec/requests/dash_board_spec.rb
+++ b/spec/requests/dash_board_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.describe "DashBoards", type: :request do
   describe "GET /dash_boardsをテストする" do
     context "ログインせずにdash_boardsにアクセスする" do
-      it "リダイレクトする" do
+      it "ログイン画面へリダイレクトする" do
       get dash_boards_path
       expect(response).to redirect_to(login_path)
+      follow_redirect!
+      expect(response.body).to include("ログインしてください")
       end
     end
   end

--- a/spec/requests/user_sessions_spec.rb
+++ b/spec/requests/user_sessions_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "UserSessions", type: :request do
         expect(response).to redirect_to(dash_boards_path)
         follow_redirect!
         expect(response.body).to include("ダッシュボード")
+        expect(response.body).to include("ログインが成功しました")
       end
     end
 
@@ -32,6 +33,7 @@ RSpec.describe "UserSessions", type: :request do
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("ログインする")
+        expect(response.body).to include("ログインが失敗しました")
       end
     end
   end
@@ -48,6 +50,7 @@ RSpec.describe "UserSessions", type: :request do
       expect(response).to redirect_to(root_path)
       follow_redirect!
       expect(response.body).to include("仮のランディングページ")
+      expect(response.body).to include("ログアウトしました")
     end
   end
 end

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Users", type: :request do
         follow_redirect!
 
         expect(response.body).to include("ダッシュボード")
+        expect(response.body).to include("ユーザー登録が成功しました")
       end
     end
           context "異常系" do
@@ -35,6 +36,7 @@ RSpec.describe "Users", type: :request do
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("新規登録")
+        expect(response.body).to include("ユーザー登録が失敗しました")
       end
     end
   end


### PR DESCRIPTION
## 概要
ここまで追加した機能にフラッシュメッセージを追加
- ログイン
- ログアウト
- 新規作成
- ログインしていない状態でのログイン必須ページへのアクセスでログインページへリダイレクト

Close #66 

## 実装内容
### 予定していた作業
- [x] layoutの方でフラッシュメッセージの表示をできるように編集
  - [x] flash.eachを使用
  - [x] alertやらnoticeによってdaisyuUIのclassの変更をするヘルパーを作成(app/helpers/application_helper.rbを作成)

- [x] 新規作成機能のフラッシュメッセージを表示するようにアクションを編集
  - [x] 成功時
  - [x] 失敗時
- [x] ログイン
  - [x] 成功
  - [x] 失敗
- [x] ログアウト
  - [x] したことの確認
  - [x] ログアウトボタン押した時の確認画面(モーダルturbo-confirm)
- [x]  ログイン必須画面でログインできていない時に”ログインしてください”と表示(applicaiton_controller.rbのnot_authenticatedに対して追加)


- [x] requestsテストの更新？(フラッシュメッセージを出せているか)
  - [x] user_spec.rb
  - [x] user_sessions_spec.rb
  - [x] dash_boards_spec.rb


## 動作確認

- [x] 新規作成機能
  - [x] 成功時"ユーザー登録が成功しました"
  - [x] 失敗時"ユーザー登録が失敗しました"
- [x] ログイン
  - [x] 成功 "ログインが成功しました"
  - [x] 失敗 "ログインが失敗しました"
- [x] ログアウト
  - [x] ログアウトボタン押した時の確認画面(モーダルのためテストには含められない)`turbo_confirm: "ログアウトしますか？"`
  - [x] したことの確認"ログアウトしました"
- [x] ログイン必須画面でログインできてない時"ログインしてください"


## 備考
- ログアウト確認のモーダルはrequestスペックでは見られないので今後システムスペックのときにやるとよいかも
- フラッシュメッセージが出てくる場所的にヘッダーの下にしたい場合、今後ヘッダーフッダーの共通化の際にlayouts/applicaiton.html.erbにて変えると良いかも。
-表示について
  -notice: 普通の成功系の緑の表示
  -alert: エラーとかの赤い表示
  
<img width="725" height="587" alt="image" src="https://github.com/user-attachments/assets/0ed75e2e-a47b-469a-a463-336b40ad93e0" />


