### PR TITLE
Feat/ヘッダーとフッダーをログイン前後で切り替え機能追加(共通化)

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,12 @@
 class PagesController < ApplicationController
   skip_before_action :require_login, only: %i[landing_page]
+  before_action :redirect_if_logged_in, only: [:landing_page]
   def landing_page
+  end
+
+  private
+  
+  def redirect_if_logged_in
+    redirect_to dash_boards_path if logged_in?
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,11 +1,11 @@
 class PagesController < ApplicationController
   skip_before_action :require_login, only: %i[landing_page]
-  before_action :redirect_if_logged_in, only: [:landing_page]
+  before_action :redirect_if_logged_in, only: [ :landing_page ]
   def landing_page
   end
 
   private
-  
+
   def redirect_if_logged_in
     redirect_to dash_boards_path if logged_in?
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,6 +1,6 @@
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
-  before_action :redirect_if_logged_in, only: [:new, :create]
+  before_action :redirect_if_logged_in, only: [ :new, :create ]
   def new
     @user = User.new
   end
@@ -29,7 +29,7 @@ class UserSessionsController < ApplicationController
       :password_confirmation
     )
   end
-  
+
   def redirect_if_logged_in
     redirect_to dash_boards_path if logged_in?
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,6 @@
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
+  before_action :redirect_if_logged_in, only: [:new, :create]
   def new
     @user = User.new
   end
@@ -27,5 +28,9 @@ class UserSessionsController < ApplicationController
       :password,
       :password_confirmation
     )
+  end
+  
+  def redirect_if_logged_in
+    redirect_to dash_boards_path if logged_in?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
-  before_action :redirect_if_logged_in, only: [:new, :create]
+  before_action :redirect_if_logged_in, only: [ :new, :create ]
   def new
     @user = User.new
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
+  before_action :redirect_if_logged_in, only: [:new, :create]
   def new
     @user = User.new
   end
@@ -24,5 +25,9 @@ class UsersController < ApplicationController
       :password,
       :password_confirmation
     )
+  end
+
+  def redirect_if_logged_in
+    redirect_to dash_boards_path if logged_in?
   end
 end

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -1,17 +1,3 @@
-<header class="navbar bg-base-100 shadow px-6">
-  <div class="flex-1">
-    <a class="text-xl font-bold">ifthen maker</a>
-  </div>
-  <div class="flex-none gap-2">
-    <%= link_to "ログアウト",
-            logout_path,
-            data: {
-              turbo_method: :delete,
-              turbo_confirm: "ログアウトしますか？"
-            },
-            class: "btn btn-outline btn-error" %>
-  </div>
-</header>
 <main class="hero min-h-[70vh] bg-base-200">
   <div class="hero-content text-center">
     <div class="max-w-md">

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -16,13 +16,3 @@
     </div>
   </div>
 </main>
-<footer class="footer footer-center p-6 text-base-content bg-base-100 shadow">
-  <div>
-    <div class="flex gap-4 bg-configtest">
-      <a href="#" class="link link-hover">ホーム</a>
-      <a href="#" class="link link-hover">習慣一覧</a>
-      <a href="#" class="link link-hover">メモ一覧</a>
-      <a href="#" class="link link-hover">振り返り一覧</a>
-    </div>
-  </div>
-</footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,5 +29,10 @@
       </div>
     <% end %>
     <%= yield %>
+    <% if logged_in? %>
+      <%= render "shared/footer_logged_in" %>
+    <% else %>
+      <%= render "shared/footer_guest" %>
+    <% end %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,11 @@
   </head>
 
   <body>
+    <% if logged_in? %>
+      <%= render "shared/header_logged_in" %>
+    <% else %>
+      <%= render "shared/header_guest" %>
+    <% end %>
     <% flash.each do |type, message| %>
       <div class="alert <%= flash_class(type) %> mb-4">
         <span><%= message %></span>

--- a/app/views/pages/landing_page.html.erb
+++ b/app/views/pages/landing_page.html.erb
@@ -28,15 +28,3 @@
     </div>
   </div>
 </main>
-
-<footer class="footer footer-center p-6 text-base-content">
-  <div>
-    <p>
-      &copy; <%= Time.current.year %> IFTHENMAKER.
-    </p>
-    <div class="flex gap-4 bg-configtest">
-      <a href="#" class="link link-hover">プライバシーポリシー</a>
-      <a href="#" class="link link-hover">利用規約</a>
-    </div>
-  </div>
-</footer>

--- a/app/views/pages/landing_page.html.erb
+++ b/app/views/pages/landing_page.html.erb
@@ -1,13 +1,3 @@
-<header class="navbar bg-base-100 shadow px-6">
-  <div class="flex-1">
-    <a href= <%= root_path %> class="text-xl font-bold">ifthen maker</a>
-  </div>
-  <div class="flex-none gap-2">
-    <a href=<%= new_user_path %> class="btn btn-ghost">新規登録</a>
-    <a href=<%= login_path %> class="btn btn-outline btn-primary">ログイン</a>
-  </div>
-</header>
-
 <main class="hero min-h-[70vh] bg-base-200">
   <div class="hero-content text-center">
     <div class="max-w-md">

--- a/app/views/shared/_footer_guest.html.erb
+++ b/app/views/shared/_footer_guest.html.erb
@@ -1,0 +1,11 @@
+<footer class="footer footer-center p-6 text-base-content">
+  <div>
+    <p>
+      &copy; <%= Time.current.year %> IFTHENMAKER.
+    </p>
+    <div class="flex gap-4 bg-configtest">
+      <a href="#" class="link link-hover">プライバシーポリシー</a>
+      <a href="#" class="link link-hover">利用規約</a>
+    </div>
+  </div>
+</footer>

--- a/app/views/shared/_footer_logged_in.html.erb
+++ b/app/views/shared/_footer_logged_in.html.erb
@@ -1,0 +1,10 @@
+<footer class="footer footer-center p-6 text-base-content bg-base-100 shadow">
+  <div>
+    <div class="flex gap-4 bg-configtest">
+      <a href="#" class="link link-hover">ホーム</a>
+      <a href="#" class="link link-hover">習慣一覧</a>
+      <a href="#" class="link link-hover">メモ一覧</a>
+      <a href="#" class="link link-hover">振り返り一覧</a>
+    </div>
+  </div>
+</footer>

--- a/app/views/shared/_header_guest.html.erb
+++ b/app/views/shared/_header_guest.html.erb
@@ -1,0 +1,9 @@
+<header class="navbar bg-base-100 shadow px-6">
+  <div class="flex-1">
+    <a href= <%= root_path %> class="text-xl font-bold">ifthen maker</a>
+  </div>
+  <div class="flex-none gap-2">
+    <a href=<%= new_user_path %> class="btn btn-ghost">新規登録</a>
+    <a href=<%= login_path %> class="btn btn-outline btn-primary">ログイン</a>
+  </div>
+</header>

--- a/app/views/shared/_header_logged_in.html.erb
+++ b/app/views/shared/_header_logged_in.html.erb
@@ -1,0 +1,14 @@
+<header class="navbar bg-base-100 shadow px-6">
+  <div class="flex-1">
+    <a class="text-xl font-bold">ifthen maker</a>
+  </div>
+  <div class="flex-none gap-2">
+    <%= link_to "ログアウト",
+            logout_path,
+            data: {
+              turbo_method: :delete,
+              turbo_confirm: "ログアウトしますか？"
+            },
+            class: "btn btn-outline btn-error" %>
+  </div>
+</header>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -35,14 +35,4 @@
   </div>
   </div>
 </main>
-<footer class="footer footer-center p-6 text-base-content">
-  <div>
-    <p>
-      &copy; <%= Time.current.year %> IFTHENMAKER.
-    </p>
-    <div class="flex gap-4 bg-configtest">
-      <a href="#" class="link link-hover">プライバシーポリシー</a>
-      <a href="#" class="link link-hover">利用規約</a>
-    </div>
-  </div>
-</footer>
+

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,10 +1,3 @@
-<header class="navbar bg-base-100 shadow px-6">
-  <div class="flex-1">
-    <a href= <%= root_path %> class="text-xl font-bold">ifthen maker</a>
-  </div>
-  <div class="flex-none gap-2">
-  </div>
-</header>
 <main class="hero min-h-[70vh] bg-base-200">
   <div class="hero-content text-center">
     <div class="card w-full max-w-md shadow-xl bg-base-100">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,10 +1,3 @@
-<header class="navbar bg-base-100 shadow px-6">
-  <div class="flex-1">
-    <a href= <%= root_path %> class="text-xl font-bold">ifthen maker</a>
-  </div>
-  <div class="flex-none gap-2">
-  </div>
-</header>
 <main class="hero min-h-[70vh] bg-base-200">
   <div class="hero-content text-center">
     <div class="card w-full max-w-md shadow-xl bg-base-100">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -57,14 +57,4 @@
   </div>
   </div>
 </main>
-<footer class="footer footer-center p-6 text-base-content">
-  <div>
-    <p>
-      &copy; <%= Time.current.year %> IFTHENMAKER.
-    </p>
-    <div class="flex gap-4 bg-configtest">
-      <a href="#" class="link link-hover">プライバシーポリシー</a>
-      <a href="#" class="link link-hover">利用規約</a>
-    </div>
-  </div>
-</footer>
+


### PR DESCRIPTION

## 概要
- パーシャルを使ってヘッダーとフッダーをログイン前後で切り替える機能追加
- ログイン状態でLPなどの未ログイン前提の画面に遷移した時、ダッシュボードにリダイレクトする機能を追加
Close #64 

## 実装内容
### 予定していた作業
- [x] ログイン後のヘッダーを追加
- [x] ログイン前のヘッダーを追加
- [x] ログイン後のフッダーを追加
- [x] ログイン後のフッダーを追加
- [x] それぞれをlayoutsで制御する


### 予定外だが実施した作業
- [x] ログイン状態でLPなどの未ログイン前提の画面に遷移した時、ダッシュボードにリダイレクトする機能を追加（LPにログイン後のヘッダーが表示されたり、動線がおかしくなり、混乱をもたらすため）

## 動作確認 localhost:3000としてブラウザで確認
- [x]  ログイン画面、ユーザー新規作成画面、LPではログイン前のヘッダーとフッダーが表示されること
- [x] ダッシュボードではログイン後のヘッダーとフッダーが表示されること
- [x] ログイン状態でLPなどの未ログイン前提の画面に遷移した時、ダッシュボードにリダイレクトする


## 備考
 テストについてはsystemとして別で書く