### PR TITLE
Hotfix/ログイン画面からの最初のログインが内容が合っていてもログイン失敗する問題の修正

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -2,12 +2,11 @@ class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
   before_action :redirect_if_logged_in, only: [ :new, :create ]
   def new
-    @user = User.new
   end
 
   def create
-    @user = login(params[:email], params[:password])
-    if @user
+    user = login(params[:email], params[:password])
+    if user
       redirect_to dash_boards_path, notice: "ログインが成功しました"
     else
       flash.now[:alert] = "ログインが失敗しました"
@@ -21,14 +20,6 @@ class UserSessionsController < ApplicationController
   end
 
   private
-
-  def user_params
-    params.require(:user).permit(
-      :email,
-      :password,
-      :password_confirmation
-    )
-  end
 
   def redirect_if_logged_in
     redirect_to dash_boards_path if logged_in?

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -5,9 +5,7 @@
       <h1 class="text-4xl font-bold text-center mb-4">
         ログイン
       </h1>
-
-
-      <%= form_with model: @user, url: login_path, local: true, class: "space-y-4" do |f| %>
+      <%= form_with url: login_path, local: true, class: "space-y-4" do |f| %>
 
         <!-- Email -->
         <div class="form-control">


### PR DESCRIPTION
## 概要
誤ったやり方で作られていたログインフォームを修正。

###問題点
これまで@userでモデル前提で作られていたせいで、sorceryがログインのために期待していた形ではない形でparamsを送るフォームになっていた。

具体的には、sorceryが期待している形が
```
params=[email: "...", password  "..."]

```

であるところが、`form_with model:@user`により
```
params = {
  user: {
    email: "...",
    password: "..."
  }
}
```
として不要なネスト構造で送信するフォームになっていた。
一度ログイン失敗した後の２回目のフォームが問題なかったのは#createにおいて`@user = login(params[:email], params[:password])`にしていたため。
これにより偶然２回目#createの時のログインフォームの送信の形式が適切なものになっていた。


Close #73 

## 実装内容

- [x] 誤ったフォームをurl指定のみのものに修正
- [x] 不要だった箇所をuser_sessions_controllerから削除


## 動作確認
- [x] 一度目のログインフォームからログインできる 


## 備考
- sorceryのログインではそのままのparamsを使うと覚える
- したがって作るべきログインフォームでもモデルは使わない
- sorceryの資料ではform_tagというのが参考資料にあるが、別にこれは必須ではない。paramsから直に値が渡されているのとurlさえ適切なら問題なし。
- これにより、一度失敗するとそれまでフォームに入れていた内容が消えるようになった。しかしセキュリティ的にも消えることに理由はありそうなのでこのままとする