### PR TITLE
Add/IfThenRuleモデルの追加

### DIFF
--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -1,7 +1,7 @@
 class IfThenRule < ApplicationRecord
   belongs_to :user
   belongs_to :memo
-  
+
   enum status: { draft: 0, active: 1, done: 2 }
   validates :if_condition, presence: true, if: :active?
   validates :then_action, presence: true, if: :active?

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -1,0 +1,4 @@
+class IfThenRule < ApplicationRecord
+  belongs_to :user
+  belongs_to :memo
+end

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -5,4 +5,5 @@ class IfThenRule < ApplicationRecord
   enum status: { draft: 0, active: 1, done: 2 }
   validates :if_condition, presence: true, if: :active?
   validates :then_action, presence: true, if: :active?
+  validates :status, presence: true
 end

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -1,4 +1,8 @@
 class IfThenRule < ApplicationRecord
   belongs_to :user
   belongs_to :memo
+  
+  enum status: { draft: 0, active: 1, done: 2 }
+  validates :if_condition, presence: true, if: :active?
+  validates :then_action, presence: true, if: :active?
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -1,5 +1,6 @@
 class Memo < ApplicationRecord
   belongs_to :user
+  has_many :if_then_rules, dependent: :destroy
   validates :title, presence: :true, length: { maximum: 100 }
   validates :body, length: { maximum: 10_000 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :memos, dependent: :destroy
+  has_many :if_then_rules, dependent: :destroy
   validates :email, presence: true, uniqueness: true
 
   validates :password,

--- a/db/migrate/20251230032926_create_if_then_rules.rb
+++ b/db/migrate/20251230032926_create_if_then_rules.rb
@@ -1,0 +1,13 @@
+class CreateIfThenRules < ActiveRecord::Migration[7.2]
+  def change
+    create_table :if_then_rules do |t|
+      t.text :situation
+      t.text :action
+      t.integer :status, null: false, default: 0
+      t.references :user, null: false, foreign_key: true
+      t.references :memo, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251230032926_create_if_then_rules.rb
+++ b/db/migrate/20251230032926_create_if_then_rules.rb
@@ -1,8 +1,8 @@
 class CreateIfThenRules < ActiveRecord::Migration[7.2]
   def change
     create_table :if_then_rules do |t|
-      t.text :situation
-      t.text :action
+      t.text :if_condition
+      t.text :then_action
       t.integer :status, null: false, default: 0
       t.references :user, null: false, foreign_key: true
       t.references :memo, null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_30_032926) do
   enable_extension "plpgsql"
 
   create_table "if_then_rules", force: :cascade do |t|
-    t.text "situation"
-    t.text "action"
+    t.text "if_condition"
+    t.text "then_action"
     t.integer "status", default: 0, null: false
     t.bigint "user_id", null: false
     t.bigint "memo_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_28_043837) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_30_032926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "if_then_rules", force: :cascade do |t|
+    t.text "situation"
+    t.text "action"
+    t.integer "status", default: 0, null: false
+    t.bigint "user_id", null: false
+    t.bigint "memo_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["memo_id"], name: "index_if_then_rules_on_memo_id"
+    t.index ["user_id"], name: "index_if_then_rules_on_user_id"
+  end
 
   create_table "memos", force: :cascade do |t|
     t.string "title", null: false
@@ -32,5 +44,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_28_043837) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "if_then_rules", "memos"
+  add_foreign_key "if_then_rules", "users"
   add_foreign_key "memos", "users"
 end

--- a/spec/factories/if_then_rules.rb
+++ b/spec/factories/if_then_rules.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :if_then_rule do
     if_condition { "test_condition" }
-    then_action {"test_action"}
+    then_action { "test_action" }
   end
 end

--- a/spec/factories/if_then_rules.rb
+++ b/spec/factories/if_then_rules.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :if_then_rule do
+    if_condition { "test_condition" }
+    then_action {"test_action"}
+  end
+end

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe IfThenRule, type: :model do
-  let(:user) { create(:user)}
+  let(:user) { create(:user) }
   let(:memo) { create(:memo, user: user) }
   describe "statusがactiveかdraft含めてバリデーションの確認" do
     context "statusがdraftの時" do

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe IfThenRule, type: :model do
+  let(:user) { create(:user)}
+  let(:memo) { create(:memo, user: user) }
+  describe "statusがactiveかdraft含めてバリデーションの確認" do
+    context "statusがdraftの時" do
+      it 'ifやthenの値がnilでもdraft状態ならバリデーションが機能しないでvalidになる' do
+        if_then_rule = build(:if_then_rule, if_condition: nil, then_action: nil, user: user, memo: memo, status: :draft)
+
+        expect(if_then_rule).to be_valid
+        expect(if_then_rule.errors).to be_empty
+      end
+    end
+    context "statusがactiveの時" do
+      it 'if_conditionの値がnilだとバリデーションが機能してinvalidになる' do
+        if_then_rule = build(:if_then_rule, if_condition: nil, user: user, memo: memo, status: :active)
+
+        expect(if_then_rule).not_to be_valid
+        expect(if_then_rule.errors[:if_condition]).to include("can't be blank")
+      end
+      it 'then_actionの値がnilだとバリデーションが機能してinvalidになる' do
+        if_then_rule = build(:if_then_rule, then_action: nil, user: user, memo: memo, status: :active)
+
+        expect(if_then_rule).not_to be_valid
+        expect(if_then_rule.errors[:then_action]).to include("can't be blank")
+      end
+      it 'then_actionの値があればバリデーションが機能してvalidになる' do
+        if_then_rule = build(:if_then_rule, user: user, memo: memo, status: :active)
+
+        expect(if_then_rule).to be_valid
+        expect(if_then_rule.errors).to be_empty
+      end
+    end
+  end
+
+  describe "バリデーションstatus" do
+    it "statusがnilの場合invalidになる" do
+      if_then_rule = build(:if_then_rule, user: user, memo: memo, status: nil)
+
+      expect(if_then_rule).not_to be_valid
+      expect(if_then_rule.errors[:status]).to include("can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
-IfThenRuleモデルの追加(MVP予定の最小構成)
-マイグレーション実行
-アソシエーション設定
-バリデーション追加
Close #22 

## 実装内容
### 予定していた作業
- [x] situation(if部分)
- [x] action (then部分)
- [x] status （enum: draft:0 / active:1 / done:2  MVP最小）
  - [x] デフォルト値をdraftとする
- [x] usersとmemosとの関連付け

- [x] マイグレーションの実行
- [x] モデルのバリデーション設定
- [x] モデルのテスト作る
### 予定外だが実施した作業

- [x] if部分とthen部分の属性名がわかりにくいので名前の変更
- [x]  if部分とthen部分の属性にはデータベース側でnot_nullにはしない形に。->mvp外にはなるが将来的に下書き機能を作る可能性のため。
- [x] 同じ理由でifとthenのバリデーションはstatusが"active"の時のみに実行するように設定

## 動作確認
- [x]  statusがdraftの時ではif_conditionとthen_actionのnilのバリデーションはしない。
- [x]  statusがactiveの時だとif_conditionとthen_actionのnilのバリデーションをする
- [x]  statusについてはnilのバリデーションを常にする 


## 備考
- ひとまずdone状態のifthenruleを編集しない方向で考えているため、activeの時のみバリデーションをするように設定している

以下現在の状態

```mermaid
erDiagram

    %% =========================
    %% Tables
    %% =========================

    users {

    }

    memos {

    }

    if_then_rules {
        bigint id PK
        bigint user_id FK "NOT NULL"
        bigint memo_id FK "NOT NULL"
        string if_condition "下書き保存可能にするため制約つけず"
        string then_action "下書き保存可能にするため制約つけず"
        int status "NOT NULL (enum){ draft: 0, active: 1, done: 2 }"
        datetime created_at "NOT NULL"
        datetime updated_at "NOT NULL"
    }


    %% =========================
    %% Relations
    %% =========================

    users ||--o{ memos : "has many"
    users ||--o{ if_then_rules : "has many"
    memos ||--o{ if_then_rules : "has many"
