### PR TITLE
Feat/ifthenrule create flow step1

### DIFF
--- a/app/controllers/if_then_rules/flows_controller.rb
+++ b/app/controllers/if_then_rules/flows_controller.rb
@@ -1,5 +1,6 @@
 class IfThenRules::FlowsController < ApplicationController
   def step1
+     @memos = current_user.memos.order(created_at: :desc)
   end
 
   def step1_submit

--- a/app/controllers/if_then_rules/flows_controller.rb
+++ b/app/controllers/if_then_rules/flows_controller.rb
@@ -1,0 +1,19 @@
+class IfThenRules::FlowsController < ApplicationController
+  def step1
+  end
+
+  def step1_submit
+  end
+
+  def step2
+  end
+
+  def step2_submit
+  end
+
+  def step3
+  end
+
+  def step3_submit
+  end
+end

--- a/app/controllers/if_then_rules/flows_controller.rb
+++ b/app/controllers/if_then_rules/flows_controller.rb
@@ -3,18 +3,18 @@ class IfThenRules::FlowsController < ApplicationController
      @memos = current_user.memos.order(created_at: :desc)
   end
 
-  def step1_submit
-  end
+  # def step1_submit
+  # end
 
-  def step2
-  end
+  # def step2
+  # end
 
-  def step2_submit
-  end
+  # def step2_submit
+  # end
 
-  def step3
-  end
+  # def step3
+  # end
 
-  def step3_submit
-  end
+  # def step3_submit
+  # end
 end

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -1,8 +1,10 @@
 class IfThenRulesController < ApplicationController
   def index
+    @if_then_rules = current_user.if_then_rules.includes(:memo)
   end
 
   def show
+    @if_then_rule = current_user.if_then_rules.find(params[:id])
   end
 
   def new

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -1,0 +1,7 @@
+class IfThenRulesController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+end

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -4,4 +4,26 @@ class IfThenRulesController < ApplicationController
 
   def show
   end
+
+  def new
+  @if_then_rule = current_user.if_then_rules.build(memo_id: params[:memo_id])
+  end
+
+  def create
+    @if_then_rule = current_user.if_then_rules.build(if_then_rule_params)
+
+    if @if_then_rule.save
+      redirect_to @if_then_rule, notice: "If-Thenルールを作成しました"
+    else
+      flash.now[:alert] = "If-Thenルールの作成が失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def if_then_rule_params
+    params.require(:if_then_rule)
+          .permit(:memo_id, :if_condition, :then_action)
+  end
 end

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -10,7 +10,7 @@ class MemosController < ApplicationController
   def create
     @memo = current_user.memos.build(memo_params)
     if @memo.save
-      redirect_to memos_path, notice: "メモの作成が成功しました"
+      redirect_to @memo, notice: "メモの作成が成功しました"
     else
       flash.now[:alert] = "メモの作成が失敗しました"
       render :new, status: :unprocessable_content

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -10,7 +10,7 @@
       </div>
 
       <div class="mt-12 flex flex-col gap-3">
-        <a href="#" class="btn btn-primary"> 新しく習慣を作成する</a>
+        <%= link_to "新しく習慣を作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
       </div>
 
     </div>

--- a/app/views/if_then_rules/flows/step1.html.erb
+++ b/app/views/if_then_rules/flows/step1.html.erb
@@ -3,9 +3,33 @@
     <div class="max-w-md">
       <h1 class="text-4xl font-bold">ステップ１-メモの選択</h1>
 
-      <div class="mt-12 flex flex-col gap-3">
-        <%= link_to "既存のメモ一覧から選択する", memos_path, class:"btn btn-primary" %>
+<p class="mb-6 text-gray-600">
+  元にするメモを選択してください
+</p>
+
+<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+  <% @memos.each do |memo| %>
+    <div class="card bg-base-100 shadow-sm border">
+      <div class="card-body">
+        <h2 class="card-title text-base">
+          <%= memo.title %>
+        </h2>
+
+        <% if memo.body.present? %>
+          <p class="text-sm text-gray-500 line-clamp-3">
+            <%= memo.body %>
+          </p>
+        <% end %>
+
+        <div class="card-actions justify-end mt-4">
+          <%= link_to "このメモから作る",
+                      new_if_then_rule_path(memo_id: memo.id),
+                      class: "btn btn-primary btn-sm" %>
+        </div>
       </div>
+    </div>
+  <% end %>
+</div>
 
 もしくは
       <div class="mt-12 flex flex-col gap-3">

--- a/app/views/if_then_rules/flows/step1.html.erb
+++ b/app/views/if_then_rules/flows/step1.html.erb
@@ -1,0 +1,17 @@
+<main class="hero min-h-[70vh] bg-base-200">
+  <div class="hero-content text-center">
+    <div class="max-w-md">
+      <h1 class="text-4xl font-bold">ステップ１-メモの選択</h1>
+
+      <div class="mt-12 flex flex-col gap-3">
+        <%= link_to "既存のメモ一覧から選択する", memos_path, class:"btn btn-primary" %>
+      </div>
+
+もしくは
+      <div class="mt-12 flex flex-col gap-3">
+        <%= link_to "新しくメモを作成する", new_memo_path, class:"btn btn-primary" %>
+      </div>
+
+    </div>
+  </div>
+</main>

--- a/app/views/if_then_rules/flows/step2.html.erb
+++ b/app/views/if_then_rules/flows/step2.html.erb
@@ -1,0 +1,2 @@
+<h1>IfThenRules::Flows#step2</h1>
+<p>Find me in app/views/if_then_rules/flows/step2.html.erb</p>

--- a/app/views/if_then_rules/flows/step3.html.erb
+++ b/app/views/if_then_rules/flows/step3.html.erb
@@ -1,0 +1,2 @@
+<h1>IfThenRules::Flows#step3</h1>
+<p>Find me in app/views/if_then_rules/flows/step3.html.erb</p>

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -1,0 +1,2 @@
+<h1>IfThenRules#index</h1>
+<p>Find me in app/views/if_then_rules/index.html.erb</p>

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -1,2 +1,43 @@
-<h1>IfThenRules#index</h1>
-<p>Find me in app/views/if_then_rules/index.html.erb</p>
+<h1 class="text-xl font-semibold mb-6">
+  If-Thenルール一覧
+</h1>
+
+<% if @if_then_rules.any? %>
+  <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <% @if_then_rules.each do |rule| %>
+      <div class="card bg-base-100 border shadow-sm">
+        <div class="card-body">
+          <h2 class="text-sm font-medium text-gray-500">
+            IF
+          </h2>
+          <p class="mb-2">
+            <%= rule.if_condition %>
+          </p>
+
+          <h2 class="text-sm font-medium text-gray-500">
+            THEN
+          </h2>
+          <p class="mb-4">
+            <%= rule.then_action %>
+          </p>
+
+          <% if rule.memo.present? %>
+            <p class="text-xs text-gray-400 mb-2">
+              元メモ：<%= rule.memo.title.presence || "（無題）" %>
+            </p>
+          <% end %>
+
+          <div class="card-actions justify-end">
+            <%= link_to "詳細を見る",
+                        if_then_rule_path(rule),
+                        class: "btn btn-outline btn-sm" %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <p class="text-gray-500">
+    まだIf-Thenルールはありません。
+  </p>
+<% end %>

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -20,6 +20,11 @@
           <p class="mb-4">
             <%= rule.then_action %>
           </p>
+          <div>
+            <p class="tag bg-accent text-white inline-block mr-2 px-2.5 py-0.5">
+              <%= rule.status %>
+            </p>
+          </div>
 
           <% if rule.memo.present? %>
             <p class="text-xs text-gray-400 mb-2">

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -1,17 +1,26 @@
-<h1>If-Thenルール作成</h1>
+<h1 class="text-xl font-semibold mb-6">
+  If-Thenルール作成
+</h1>
 
-<%= form_with model: @if_then_rule do |f| %>
+<%= form_with model: @if_then_rule, class: "max-w-md space-y-6" do |f| %>
   <%= f.hidden_field :memo_id %>
 
-  <div>
-    <%= f.label :if_condition, "IF（きっかけ）" %><br>
-    <%= f.text_field :if_condition %>
+  <div class="form-control">
+    <%= f.label :if_condition, "IF（きっかけ）", class: "label" %>
+    <%= f.text_field :if_condition,
+                     class: "input input-bordered",
+                     placeholder: "例：朝7時に起きたら" %>
   </div>
 
-  <div>
-    <%= f.label :then_action, "THEN（行動）" %><br>
-    <%= f.text_field :then_action %>
+  <div class="form-control">
+    <%= f.label :then_action, "THEN（行動）", class: "label" %>
+    <%= f.text_field :then_action,
+                     class: "input input-bordered",
+                     placeholder: "例：コップ一杯の水を飲む" %>
   </div>
 
-  <%= f.submit "作成する" %>
+  <div class="pt-4">
+    <%= f.submit "作成する",
+                 class: "btn btn-primary w-full" %>
+  </div>
 <% end %>

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -1,0 +1,17 @@
+<h1>If-Thenルール作成</h1>
+
+<%= form_with model: @if_then_rule do |f| %>
+  <%= f.hidden_field :memo_id %>
+
+  <div>
+    <%= f.label :if_condition, "IF（きっかけ）" %><br>
+    <%= f.text_field :if_condition %>
+  </div>
+
+  <div>
+    <%= f.label :then_action, "THEN（行動）" %><br>
+    <%= f.text_field :then_action %>
+  </div>
+
+  <%= f.submit "作成する" %>
+<% end %>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -1,2 +1,45 @@
-<h1>IfThenRules#show</h1>
-<p>Find me in app/views/if_then_rules/show.html.erb</p>
+<h1 class="text-xl font-semibold mb-6">
+  If-Thenルール詳細
+</h1>
+
+<div class="max-w-lg space-y-6">
+  <div class="card bg-base-100 border">
+    <div class="card-body">
+      <div>
+        <h2 class="text-sm font-medium text-gray-500 mb-1">
+          IF（トリガー）
+        </h2>
+        <p class="text-base">
+          <%= @if_then_rule.if_condition %>
+        </p>
+      </div>
+
+      <div>
+        <h2 class="text-sm font-medium text-gray-500 mb-1">
+          THEN（行動）
+        </h2>
+        <p class="text-base">
+          <%= @if_then_rule.then_action %>
+        </p>
+      </div>
+
+      <% if @if_then_rule.memo.present? %>
+        <div class="pt-4 border-t">
+          <h2 class="text-sm font-medium text-gray-500 mb-1">
+            元にしたメモ
+          </h2>
+          <p class="text-sm">
+            <%= @if_then_rule.memo.title.presence || "（無題のメモ）" %>
+          </p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="flex gap-2">
+    <%= link_to "一覧に戻る",
+                if_then_rules_path,
+                class: "btn btn-outline btn-sm" %>
+
+  </div>
+</div>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -1,0 +1,2 @@
+<h1>IfThenRules#show</h1>
+<p>Find me in app/views/if_then_rules/show.html.erb</p>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -23,6 +23,12 @@
         </p>
       </div>
 
+      <div>
+        <p class="tag bg-accent text-white inline">
+          <%= @if_then_rule.status %>
+        </p>
+      </div>
+
       <% if @if_then_rule.memo.present? %>
         <div class="pt-4 border-t">
           <h2 class="text-sm font-medium text-gray-500 mb-1">

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -29,8 +29,8 @@
 
     <!-- 習慣化ボタン -->
     <div>
-      <%= button_to "このメモを習慣にする",
-                    "#",
+      <%= link_to "このメモを習慣にする",
+                    new_if_then_rule_path(memo_id: @memo.id) ,
                     class: "btn btn-primary w-full" %>
     </div>
   </div>

--- a/app/views/shared/_footer_logged_in.html.erb
+++ b/app/views/shared/_footer_logged_in.html.erb
@@ -2,7 +2,7 @@
   <div>
     <div class="flex gap-4 bg-configtest">
       <%= link_to "ダッシュボード", dash_boards_path, class:"link link-hover" %>
-      <a href="#" class="link link-hover">習慣一覧</a>
+      <%= link_to "習慣一覧", if_then_rules_path, class:"link link-hover" %>
       <a href=<%= memos_path %> class="link link-hover">メモ一覧</a>
       <a href="#" class="link link-hover">振り返り一覧</a>
     </div>

--- a/app/views/shared/_footer_logged_in.html.erb
+++ b/app/views/shared/_footer_logged_in.html.erb
@@ -4,7 +4,7 @@
       <%= link_to "ダッシュボード", dash_boards_path, class:"link link-hover" %>
       <%= link_to "習慣一覧", if_then_rules_path, class:"link link-hover" %>
       <a href=<%= memos_path %> class="link link-hover">メモ一覧</a>
-      <a href="#" class="link link-hover">振り返り一覧</a>
+      <a href="#" class="link link-hover text-gray-400">振り返り一覧</a>
     </div>
   </div>
 </footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,11 +16,11 @@ Rails.application.routes.draw do
   namespace :if_then_rules do
     resource :flow do
       get :step1
-      post :step1, action: :step1_submit
-      get :step2
-      post :step2, action: :step2_submit
-      get :step3
-      post :step3, action: :step3_submit
+      # post :step1, action: :step1_submit
+      # get :step2
+      # post :step2, action: :step2_submit
+      # get :step3
+      # post :step3, action: :step3_submit
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   # メモの機能->memos
   resources :memos
   # ifthenの表示機能->if_then_rules
-  resources :if_then_rules, only: %i[ index show ]
+  resources :if_then_rules, only: %i[ index show new create]
   # ifthenの作成機能(ステップUI)->if_then_rules/flows
   namespace :if_then_rules do
     resource :flow do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,18 @@ Rails.application.routes.draw do
   get  "/login",  to: "user_sessions#new"
   post "/login",  to: "user_sessions#create"
   delete "/logout", to: "user_sessions#destroy"
-  # メモの作成機能->memos
+  # メモの機能->memos
   resources :memos
+  # ifthenの表示機能->if_then_rules
+  resources :if_then_rules, only: %i[ index show ]
+  # ifthenの作成機能(ステップUI)->if_then_flow
+    # collection do
+    #   get "/step1", to: "ifthenrules#step1_howto_select_memo"
+    #   post "/step1", to: "ifthenrules#step1_memo_post"
+
+    # end
+
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,12 +12,17 @@ Rails.application.routes.draw do
   resources :memos
   # ifthenの表示機能->if_then_rules
   resources :if_then_rules, only: %i[ index show ]
-  # ifthenの作成機能(ステップUI)->if_then_flow
-    # collection do
-    #   get "/step1", to: "ifthenrules#step1_howto_select_memo"
-    #   post "/step1", to: "ifthenrules#step1_memo_post"
-
-    # end
+  # ifthenの作成機能(ステップUI)->if_then_rules/flows
+  namespace :if_then_rules do
+    resource :flow do
+      get :step1
+      post :step1, action: :step1_submit
+      get :step2
+      post :step2, action: :step2_submit
+      get :step3
+      post :step3, action: :step3_submit
+    end
+  end
 
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Memos", type: :request do
           }
         }.to change(Memo, :count).by(1)
 
-        expect(response).to redirect_to(memos_path)
+        expect(response).to redirect_to(memo_path(Memo.first))
       end
     end
       context "異常系" do


### PR DESCRIPTION

## 概要
f_then_rule作成機能について、
当初想定していたステップUI（step1〜3）を見直し、
メモ選択 → if / then入力 → 作成 の2段階で実装した。
	-	step1では、元にするメモの選択、または新規メモ作成を行う
	-	step2で if_condition / then_action を入力し、if_then_ruleを作成する


もともとは
step2, step3で if / then を分けて入力するステップUI
を複数イシューで実装する予定だったが、
	-	ステップUI自体が本当に必要か不明
	-	MVPとして検証したい価値と関係が薄い(多分)
という感じで判断。今回のイシューでは step1〜作成までを最小構成で実装した。

なお、step1のみ「既存メモを選ぶ / その場で新規作成する」
という分岐があるため、ここだけはステップ的な構造を残している。

Close #24 

## 実装内容
### 予定していた作業
- [x] if_then_rulesのコントローラー作成
- [x]  if_then_rules::flowsコントローラーの作成

- [x] ダッシュボードからのifthenルールの新規作成機能として最初に入る画面をつくる
  - [x] 既存メモ一覧表示機能への導線(メモ一覧への遷移)
  - [x] 新規メモ作成をする機能への導線(新規メモ作成への遷移)
  - [x] routesの作成

- [x] 新規メモ作成をしたのちにifthenの作成のフローに戻る動線 (このメモで作成するボタンがあるメモの詳細画面)
- [x] 「このメモでifthenルールを作成する」ボタンとしてifthenのフローのifの作成へ遷移する



### 予定外だが実施した作業
- [x] MVPの範囲の見直し(ステップUIが本当に必要疑問があったため)
- [x] ifとthenの部分もそのまま入力して習慣として作成する機能(mvpの変更に伴い次のイシューであるifthenのバリデーション実装と結びつけやすくするため)
- [x] if_then_rulesの一覧表示機能実装(変化がわかりやすい)
- [x] if_then_rulesの詳細表示機能実装(変化がわかりやすい)

## 動作確認
- [x] ダッシュボードからメモを選択できる画面へ
- [x] その際にメモを新しくメモを作成するリンクを追加

[![Image from Gyazo](https://i.gyazo.com/7401916010f43ab0f4deb935ea3f2416.gif)](https://gyazo.com/7401916010f43ab0f4deb935ea3f2416)
## 備考
	そもそもステップUIを使うこと自体が価値なのか分からなくなった
	->ステップUIは使いやすさの手段であり、MVPで検証したい価値の核ではないと判断した

	そのため、該当イシューは MVP外 として整理済み