### PR TITLE
ダッシュボードでのルール一覧の表示の実装

### DIFF
--- a/app/controllers/dash_boards_controller.rb
+++ b/app/controllers/dash_boards_controller.rb
@@ -1,4 +1,5 @@
 class DashBoardsController < ApplicationController
   def index
+    @if_then_rules = current_user.if_then_rules.where(status: :active)
   end
 end

--- a/app/controllers/dash_boards_controller.rb
+++ b/app/controllers/dash_boards_controller.rb
@@ -1,5 +1,5 @@
 class DashBoardsController < ApplicationController
   def index
-    @if_then_rules = current_user.if_then_rules.where(status: :active)
+    @if_then_rules = current_user.if_then_rules
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
 
   def if_then_rule_board_view(rule)
     safe_join([
-      tag.p(rule.if_condition, class: "font-semibold"),
+      tag.p(rule.if_condition, class: "font-normal"),
       tag.p(rule.then_action, class: "font-semibold text-primary mt-4")
     ])
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,8 @@ module ApplicationHelper
     else "alert-info"
     end
   end
+
+  def if_then_rule_board_view(rule_object)
+    "もし#{rule_object.if_condition}なら#{rule_object.then_action}する"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,8 +10,8 @@ module ApplicationHelper
 
   def if_then_rule_board_view(rule)
     safe_join([
-      tag.span(rule.if_condition, class: "font-semibold"),
-      tag.span(rule.then_action, class: "font-semibold text-primary")
+      tag.p(rule.if_condition, class: "font-semibold"),
+      tag.p(rule.then_action, class: "font-semibold text-primary mt-4")
     ])
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,20 @@ module ApplicationHelper
   end
 
   def if_then_rule_board_view(rule_object)
-    "もし#{rule_object.if_condition}なら#{rule_object.then_action}する"
+    "もし#{rule_object.if_condition}なら#{rule_object.then_action}"
   end
+
+  #今後以下のような表現方法を切り替える機能があると良いかもしれない
+  # def if_then_rule_board_view(rule, style: :default)
+  # case style
+  # when :default
+  #   "もし#{rule.if_condition}なら、#{rule.then_action}"
+  # when :monologue
+  #   "#{rule.if_condition}になったら、#{rule.then_action}しよう"
+  # when :question
+  #   "#{rule.if_condition}のとき、#{rule.then_action}する？"
+  # end
+  # end
+
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,8 +8,11 @@ module ApplicationHelper
     end
   end
 
-  def if_then_rule_board_view(rule_object)
-    "もし#{rule_object.if_condition}なら#{rule_object.then_action}"
+  def if_then_rule_board_view(rule)
+    safe_join([
+      tag.span(rule.if_condition, class: "font-semibold"),
+      tag.span(rule.then_action, class: "font-semibold text-primary")
+    ])
   end
 
   #今後以下のような表現方法を切り替える機能があると良いかもしれない

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
     ])
   end
 
-  #今後以下のような表現方法を切り替える機能があると良いかもしれない
+  # 今後以下のような表現方法を切り替える機能があると良いかもしれない
   # def if_then_rule_board_view(rule, style: :default)
   # case style
   # when :default
@@ -26,6 +26,4 @@ module ApplicationHelper
   #   "#{rule.if_condition}のとき、#{rule.then_action}する？"
   # end
   # end
-
-
 end

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -17,10 +17,7 @@
           <% end %>
         </div>
         <p class="text-sm text-gray-500 mb-2">
-          実行中 <span class="font-normal"><%= "#{@if_then_rules.active.length} / #{@if_then_rules.length}" %></span>
-        </p>
-        <p class="text-sm text-gray-500 mb-2">
-          完了済み <span class="font-normal"><%= "#{@if_then_rules.done.length} / #{@if_then_rules.length}" %></span>
+          完了済み <span class="font-normal"><%= "#{@if_then_rules.done.length} " %></span>
         </p>
       <% else %>
         <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -10,12 +10,18 @@
         </h2>
 
         <div class="space-y-2">
-          <% @if_then_rules.each do |rule| %>
+          <% @if_then_rules.active.each do |rule| %>
             <div class="card bg-base-100 shadow border border-base-300 p-4">
               <%= if_then_rule_board_view(rule) %>
             </div>
           <% end %>
         </div>
+        <p class="text-sm text-gray-500 mb-2">
+          実行中 <span class="font-normal"><%= "#{@if_then_rules.active.length} / #{@if_then_rules.length}" %></span>
+        </p>
+        <p class="text-sm text-gray-500 mb-2">
+          完了済み <span class="font-normal"><%= "#{@if_then_rules.done.length} / #{@if_then_rules.length}" %></span>
+        </p>
       <% else %>
         <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>
       <% end %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -4,11 +4,16 @@
       <h1 class="text-4xl font-bold">ダッシュボード</h1>
 
 
-      <div class="card bg-base-100 shadow my-6">
-      <% @if_then_rules.each do |rule|  %>
-        <div class="card bg-base-100 shadow-lg border border-base-300"><%= if_then_rule_board_view(rule)  %></div>
-      <% end  %>
-      </div>
+      <%if @if_then_rules.any?%>
+        <div class="card bg-base-100 shadow my-6">
+          <% @if_then_rules.each do |rule|  %>
+            <div class="card bg-base-100 shadow-lg border border-base-300"><%= if_then_rule_board_view(rule)  %></div>
+          <% end  %>
+        </div>
+
+      <%else%>
+        <p class="mb-6 text-gray-600">まだルールがありません</p>
+      <%end%>
 
       <div class="mt-12 flex flex-col gap-3">
         <%= link_to "新しく習慣を作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -4,16 +4,19 @@
       <h1 class="text-4xl font-bold">ダッシュボード</h1>
 
 
-      <%if @if_then_rules.any?%>
-        <div class="card bg-base-100 shadow my-6">
-          <% @if_then_rules.each do |rule|  %>
-            <div class="card bg-base-100 shadow-lg border border-base-300"><%= if_then_rule_board_view(rule)  %></div>
-          <% end  %>
-        </div>
+      <% if @if_then_rules.any? %>
+        <ul class="list bg-base-100 rounded-box shadow my-6">
+          <% @if_then_rules.each do |rule| %>
+            <li class="list-row">
+              <%= if_then_rule_board_view(rule) %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>
+      <% end %>
 
-      <%else%>
-        <p class="mb-6 text-gray-600">まだルールがありません</p>
-      <%end%>
+      
 
       <div class="mt-12 flex flex-col gap-3">
         <%= link_to "新しく習慣を作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -1,17 +1,21 @@
 <main class="hero min-h-[70vh] bg-base-200">
   <div class="hero-content text-center">
     <div class="max-w-md">
-      <h1 class="text-4xl font-bold">ダッシュボード</h1>
+      <h1 class="text-4xl font-bold mb-4">ダッシュボード</h1>
 
 
       <% if @if_then_rules.any? %>
-        <ul class="list bg-base-100 rounded-box shadow my-6">
+        <h2 class="text-lg font-bold ">
+          今日のルール
+        </h2>
+
+        <div class="space-y-2">
           <% @if_then_rules.each do |rule| %>
-            <li class="list-row">
+            <div class="card bg-base-100 shadow border border-base-300 p-4">
               <%= if_then_rule_board_view(rule) %>
-            </li>
+            </div>
           <% end %>
-        </ul>
+        </div>
       <% else %>
         <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>
       <% end %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -3,10 +3,11 @@
     <div class="max-w-md">
       <h1 class="text-4xl font-bold">ダッシュボード</h1>
 
+
       <div class="card bg-base-100 shadow my-6">
-        <div class="card bg-base-100 shadow-lg border border-base-300">習慣</div>
-        <div class="card bg-base-100 shadow-lg border border-base-300">習慣</div>
-        <div class="card bg-base-100 shadow-lg border border-base-300">習慣</div>
+      <% @if_then_rules.each do |rule|  %>
+        <div class="card bg-base-100 shadow-lg border border-base-300"><%= if_then_rule_board_view(rule)  %></div>
+      <% end  %>
       </div>
 
       <div class="mt-12 flex flex-col gap-3">

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -1,4 +1,8 @@
-<h1 class="text-xl font-semibold mb-6">
+<% if @if_then_rules.active.count > 3 %>
+  <p class="text-sm text-yellow-600 mb-2">
+    実行中のルールが少し多いかもしれません。<%= "(３つまでを推奨していますが現在 #{@if_then_rules.active.length} つです) " %>
+  </p>
+<% end %><h1 class="text-xl font-semibold mb-6">
   If-Thenルール一覧
 </h1>
 


### PR DESCRIPTION

## 概要
- ダッシュボードでのルール一覧の表示の実装
- activeのルールが3つを超えている場合にルール一覧画面に個数に関する注意追加

Close #31 

## 実装内容
### 予定していた作業
- [x] ログインユーザーのactive状態の if_then_rulesを~3つまで~ダッシュボードで表示する　
  - [x] active状態のもののみ表示
  - [x] MVPでは「毎日実行する前提」のため日による変更はしない->週に何回などの設定は"本当にあるべきか"から考えた方が良いかも？
  - [x] ダッシュボード で"今日のルール一覧"として表示(冗長のため”今日のルールとして作成)



### 予定外だが実施した作業
- [x] ルール一覧画面に個数に関する注意を追加（後の予定だったが、タイミングとして今回が良いと判断。ただし全体のルール数あたりの個数としてダッシュボードでだすとプレッシャーを与えることになりかねないので一覧表示で注意の一部として出す形式へ）
<img width="564" height="74" alt="image" src="https://github.com/user-attachments/assets/a545d169-9891-4364-b339-1ed91156dcb0" />

## 動作確認
 - [x] ダッシュボード で~"今日のルール一覧"~"今日のルール"として表示
- [x] ダッシュボードでactiveの状態のルールが一覧表示される
  - [x] if_conditionとthen_actionの両方を表示する
<img width="412" height="605" alt="image" src="https://github.com/user-attachments/assets/aecc4397-bd71-41bf-ad97-50d260fa160d" />


## 備考
- どのように日々の「やった」を実装するか？というところから別イシューでやった方が良い(これに関してはmvp内になりそう)->そして表のしてのところに"今日の完了数"というような形で出せると良さそう


- 表示する形式について"もしxxxならxxxx"というような装飾的な文字を入れてもいいかもしれない。またそれを"rule_style"というような形でif_then_ruleのカラムに追加して表示する時に出し分ける？

特に"xxxの時,xxxする？"というような疑問形の表示形式は”実行意図”として
入れると行動科学？的にも意味がありそう。
```

  #今後以下のような表現方法を切り替える機能があると良いかもしれない
   def if_then_rule_board_view(rule, style: :default)
  case style
   when :default
     "もし#{rule.if_condition}なら、#{rule.then_action}"
   when :monologue
     "#{rule.if_condition}になったら、#{rule.then_action}しよう"
   when :question
     "#{rule.if_condition}のとき、#{rule.then_action}する？"
   end
   end
