### PR TITLE
 新規作成時にもしifthenのactive状態のルールが2つ以下ならその時作成したものを自動でactive状態にする機能

### DIFF
--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -11,30 +11,30 @@ class IfThenRulesController < ApplicationController
     @if_then_rule_form = IfThenRuleForm.new({ memo_id: params[:memo_id] }, user: current_user)
     @active_if_then_rules = current_user.if_then_rules.active
   end
-  
+
   def create
     @if_then_rule_form = IfThenRuleForm.new(if_then_rule_params, user: current_user)
     @active_if_then_rules = current_user.if_then_rules.active
-    
+
     if @if_then_rule_form.save(ignore_warnings: params[:commit_type] == "ignore_warnings")
       redirect_to if_then_rules_path, notice: "If-Thenルールを作成しました"
     else
       flash.now[:alert] = "入力内容に問題があります。" if @if_then_rule_form.errors.any?
-      
+
       flash.now[:warning] = "改善できそうな点があります。内容を確認してみてください。" if @if_then_rule_form.warnings.any?
-      
+
       render :new, status: :unprocessable_entity
     end
   end
-  
+
   def edit
     @active_if_then_rules = current_user.if_then_rules.active
     @if_then_rule = current_user.if_then_rules.find(params[:id])
-    
+
     @if_then_rule_form = IfThenRuleForm.new(user: current_user, if_then_rule_of_model: @if_then_rule)
     @if_then_rule_form.apply_model_to_form
   end
-  
+
   def update
     @active_if_then_rules = current_user.if_then_rules.active
     @if_then_rule = current_user.if_then_rules.find(params[:id])

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -15,26 +15,28 @@ class IfThenRulesController < ApplicationController
   def create
     @if_then_rule_form = IfThenRuleForm.new(if_then_rule_params, user: current_user)
     @active_if_then_rules = current_user.if_then_rules.active
-
-      if @if_then_rule_form.save(ignore_warnings: params[:commit_type] == "ignore_warnings")
-        redirect_to if_then_rules_path, notice: "If-Thenルールを作成しました"
-      else
-        flash.now[:alert] = "入力内容に問題があります。" if @if_then_rule_form.errors.any?
-
-        flash.now[:warning] = "改善できそうな点があります。内容を確認してみてください。" if @if_then_rule_form.warnings.any?
-
-        render :new, status: :unprocessable_entity
-      end
+    
+    if @if_then_rule_form.save(ignore_warnings: params[:commit_type] == "ignore_warnings")
+      redirect_to if_then_rules_path, notice: "If-Thenルールを作成しました"
+    else
+      flash.now[:alert] = "入力内容に問題があります。" if @if_then_rule_form.errors.any?
+      
+      flash.now[:warning] = "改善できそうな点があります。内容を確認してみてください。" if @if_then_rule_form.warnings.any?
+      
+      render :new, status: :unprocessable_entity
+    end
   end
-
+  
   def edit
+    @active_if_then_rules = current_user.if_then_rules.active
     @if_then_rule = current_user.if_then_rules.find(params[:id])
-
+    
     @if_then_rule_form = IfThenRuleForm.new(user: current_user, if_then_rule_of_model: @if_then_rule)
     @if_then_rule_form.apply_model_to_form
   end
-
+  
   def update
+    @active_if_then_rules = current_user.if_then_rules.active
     @if_then_rule = current_user.if_then_rules.find(params[:id])
     @if_then_rule_form = IfThenRuleForm.new(if_then_rule_params, user: current_user, if_then_rule_of_model: @if_then_rule)
 

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -11,9 +11,10 @@ class IfThenRulesController < ApplicationController
     @if_then_rule_form = IfThenRuleForm.new({ memo_id: params[:memo_id] }, user: current_user)
     @active_if_then_rules = current_user.if_then_rules.active
   end
-
+  
   def create
     @if_then_rule_form = IfThenRuleForm.new(if_then_rule_params, user: current_user)
+    @active_if_then_rules = current_user.if_then_rules.active
 
       if @if_then_rule_form.save(ignore_warnings: params[:commit_type] == "ignore_warnings")
         redirect_to if_then_rules_path, notice: "If-Thenルールを作成しました"

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -9,6 +9,7 @@ class IfThenRulesController < ApplicationController
 
   def new
     @if_then_rule_form = IfThenRuleForm.new({ memo_id: params[:memo_id] }, user: current_user)
+    @active_if_then_rules = current_user.if_then_rules.active
   end
 
   def create

--- a/app/forms/if_then_rule_form.rb
+++ b/app/forms/if_then_rule_form.rb
@@ -72,7 +72,8 @@ class IfThenRuleForm
       record = @current_user.if_then_rules.create(
       memo_id: memo_id,
       if_condition: if_condition,
-      then_action: then_action
+      then_action: then_action,
+      status: status
     )
      record.persisted?
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,13 +14,12 @@ module ApplicationHelper
       tag.p(rule.then_action, class: "font-semibold text-primary mt-4")
     ])
   end
-#新規作成でその時のactiveなルールの個数でステータスのフォームとしてのデフォルト値を変える
-  def change_default_status(active_if_then_rules,setted_status:nil)
-    #もしすでに設定済みの値があればそれを返す(warningやerrorによる再表示用)
+  # 新規作成でその時のactiveなルールの個数でステータスのフォームとしてのデフォルト値を変える
+  def change_default_status(active_if_then_rules, setted_status: nil)
+    # もしすでに設定済みの値があればそれを返す(warningやerrorによる再表示用)
     return setted_status if setted_status
-    #activeなルールの個数が3つ以上あれば初期値をdraftにする
+    # activeなルールの個数が3つ以上あれば初期値をdraftにする
     active_if_then_rules.length >= 3 ? "draft" : "active"
-
   end
 
   # 今後以下のような表現方法を切り替える機能があると良いかもしれない

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,14 @@ module ApplicationHelper
       tag.p(rule.then_action, class: "font-semibold text-primary mt-4")
     ])
   end
+#新規作成でその時のactiveなルールの個数でステータスのフォームとしてのデフォルト値を変える
+  def change_default_status(active_if_then_rules,setted_status:nil)
+    #もしすでに設定済みの値があればそれを返す(warningやerrorによる再表示用)
+    return setted_status if setted_status
+    #activeなルールの個数が3つ以上あれば初期値をdraftにする
+    active_if_then_rules.length >= 3 ? "draft" : "active"
+
+  end
 
   # 今後以下のような表現方法を切り替える機能があると良いかもしれない
   # def if_then_rule_board_view(rule, style: :default)

--- a/app/views/if_then_rules/edit.html.erb
+++ b/app/views/if_then_rules/edit.html.erb
@@ -68,6 +68,10 @@
   </div>
     <%= f.label :status, "状態", class: "label" %>
    <%= f.select :status, [["下書き", "draft"], ["実行中", "active"]] %>
+     <p class="text-sm text-gray-500 mt-1">
+  現在、実行中のルールは <%= @active_if_then_rules.length %> 件です
+</p>
+
     <div class="pt-4 space-y-3">
     <% if @if_then_rule_form.warnings.present? %>
       <% if @if_then_rule_form.errors.empty? %>

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -66,6 +66,8 @@
       </div>
     </details>
   </div>
+   <%= f.label :status, "状態", class: "label" %>
+   <%= f.select :status, [["下書き", "draft"], ["実行中", "active"]] %>
     <div class="pt-4 space-y-3">
     <% if @if_then_rule_form.warnings.present? %>
       <% if @if_then_rule_form.errors.empty? %>

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -67,7 +67,7 @@
     </details>
   </div>
    <%= f.label :status, "状態", class: "label" %>
-   <%= f.select :status, [["下書き", "draft"], ["実行中", "active"]] %>
+   <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"]], {selected: ( @active_if_then_rules.length >= 3 ? "draft" : "active")} %>
     <div class="pt-4 space-y-3">
     <% if @if_then_rule_form.warnings.present? %>
       <% if @if_then_rule_form.errors.empty? %>

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -67,7 +67,7 @@
     </details>
   </div>
    <%= f.label :status, "状態", class: "label" %>
-   <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"]], {selected: ( @active_if_then_rules.length >= 3 ? "draft" : "active")} %>
+   <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"]], {selected: change_default_status(@active_if_then_rules,setted_status:@if_then_rule_form.status)} %>
     <div class="pt-4 space-y-3">
     <% if @if_then_rule_form.warnings.present? %>
       <% if @if_then_rule_form.errors.empty? %>

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -68,6 +68,11 @@
   </div>
    <%= f.label :status, "状態", class: "label" %>
    <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"]], {selected: change_default_status(@active_if_then_rules,setted_status:@if_then_rule_form.status)} %>
+
+   <p class="text-sm text-gray-500 mt-1">
+  現在、実行中のルールは <%= @active_if_then_rules.length %> 件です
+</p>
+
     <div class="pt-4 space-y-3">
     <% if @if_then_rule_form.warnings.present? %>
       <% if @if_then_rule_form.errors.empty? %>


### PR DESCRIPTION

## 概要
新規作成時にもしifthenのactive状態のルールが2つ以下ならフォームのstatusの初期値をactive状態にする機能
逆に3つ以上ある時はdraftにする機能追加

この際、考えやすいように現在のactiveなルールの数をフォームに表示するように設定
Close #44 

## 実装内容
### 予定していた作業
- [x] 新規作成画面にstatusの項目を追加
- [x] 既存のactiveのレコードが2つまでであればフォームとしてのstatusの初期値がをactiveとする
- [x] 既存のactiveのレコードが3つ以上あればフォームとしてのstatusの初期値をdraftにする
- [x] 他editとの違いによる、想定外の事あればそれを修正->(cretateでバリデーションなどにかかった際のフォームの再表示でstatusの値が元の初期値にならないように設定) fcb2c55867eb49bc68d4fb1b1d2402557f94d8f9



### 予定外だが実施した作業
- [x] 現在のactiveなルールの数をフォームに表示するように設定（これがないと実際の使用時に考えにくいかもしれない）->新規作成画面と編集画面の両方に追加 19c33c516645c0e07a9f571fb331f6cf62e53f13

## 動作確認
- [x] 作成時点で active が2件以下なら新規ルールを activeにする(あるいは作りやすくする)
- [x] フォームのstatusセレクトの初期値をactiveにする？

- [x] 3件以上なら フォームのstatusセレクトの初期値をdraftにする？
- [x] 編集時同様にactiveが3つ以上のwarningを出す

---

###activeなルールが3つ以上の状態だと
<img width="364" height="617" alt="image" src="https://github.com/user-attachments/assets/346ee1fd-1faf-470b-b142-09c8a21544e3" />
新規作成でのstatusの初期値はdraftになる
<img width="487" height="468" alt="image" src="https://github.com/user-attachments/assets/50abfb19-0871-4ca4-8cc3-48b8fdcd9259" />

---

###activeなルールが２つ以下の状態だと
<img width="356" height="319" alt="image" src="https://github.com/user-attachments/assets/fecf4305-38dd-4552-b5c9-96fa942cd220" />
新規作成でのstatusの初期値はactiveになる
<img width="481" height="388" alt="image" src="https://github.com/user-attachments/assets/010f256e-5cbd-46d6-8175-f4dcc866eb6d" />


## 備考
- もっと使いやすくするような細かな調整は別イシュー
- またそろそろパーシャルとかを検討してもいいかも？->一括で見た目を揃えやすい