### PR TITLE
今日やったかどうかを判定できるようにする

### DIFF
--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -7,4 +7,8 @@ class IfThenRule < ApplicationRecord
   validates :if_condition, presence: true, if: :active?
   validates :then_action, presence: true, if: :active?
   validates :status, presence: true
+
+  def reflected_today?
+  reflections.exists?(reflected_on: Date.current)
+  end
 end

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -13,11 +13,15 @@
           <% @if_then_rules.active.each do |rule| %>
             <div class="card bg-base-100 shadow border border-base-300 p-4">
               <%= if_then_rule_board_view(rule) %>
-              <%= "できました!" if rule.reflected_today? %>
+              <% if rule.reflected_today? %>
+                <p>完了！</p>
+
+              <% else %>
               <%= button_to "✔️",
                 if_then_rule_reflections_path(rule),
                 method: :post,
                 class: "btn btn-sm btn-outline" %>
+              <% end %>
             </div>
           <% end %>
         </div>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -13,6 +13,7 @@
           <% @if_then_rules.active.each do |rule| %>
             <div class="card bg-base-100 shadow border border-base-300 p-4">
               <%= if_then_rule_board_view(rule) %>
+              <%= "できました!" if rule.reflected_today? %>
               <%= button_to "✔️",
                 if_then_rule_reflections_path(rule),
                 method: :post,

--- a/spec/factories/reflections.rb
+++ b/spec/factories/reflections.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :reflection do
+  end
+end

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -42,4 +42,28 @@ RSpec.describe IfThenRule, type: :model do
       expect(if_then_rule.errors[:status]).to include("can't be blank")
     end
   end
+
+  describe "#reflected_today?メソッドの確認" do
+    let(:rule) { create(:if_then_rule, user: user, memo: memo) }
+
+    context "今日のreflectionがある場合" do
+      before do
+        create(:reflection,
+          user: user,
+          if_then_rule: rule,
+          reflected_on: Date.current
+        )
+      end
+
+      it "trueを返す" do
+        expect(rule.reflected_today?).to be true
+      end
+    end
+
+    context "今日のreflectionがない場合" do
+      it "falseを返す" do
+        expect(rule.reflected_today?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
今日やったかどうかを判定できるようにするメソッドの追加(rule#reflected_today?)
最低限のボタンの反応を追加

Close #101 

## 実装内容
### 予定していた作業
- [x] if_then_ruleモデルに今日やったかどうかを判定するメソッドを追加
- [x] 上記メソッドのテストを追加



### 予定外だが実施した作業
- [x] ダッシュボードにて最低限のボタンを押した時の反応追加（メソッドが動くことの確認のため）

## 動作確認
- [x]  ブラウザにて機能することを確認
<img width="335" height="578" alt="image" src="https://github.com/user-attachments/assets/08f27bfb-7ccf-44b3-8856-246177b25a30" />

<img width="327" height="521" alt="image" src="https://github.com/user-attachments/assets/eff5a2cf-5386-4b04-a8de-64b8cd931765" />




## 備考
-  完了したその日のものはもはやボタンを隠してしまってもいいかもしれない。暗くするよりも単純にできる