### PR TITLE
ダッシュボードで今日の達成数を表示する

### DIFF
--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -14,7 +14,7 @@
             <div class="card bg-base-100 shadow border border-base-300 p-4">
               <%= if_then_rule_board_view(rule) %>
               <% if rule.reflected_today? %>
-                <p>完了！</p>
+                <p>完了済み！</p>
 
               <% else %>
               <%= button_to "✔️",

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -22,6 +22,7 @@
                 method: :post,
                 class: "btn btn-sm btn-outline" %>
               <% end %>
+              
             </div>
           <% end %>
         </div>
@@ -32,7 +33,24 @@
         <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>
       <% end %>
 
-      
+
+      <div>
+        <%= "今日やったルールの数:#{@if_then_rules.active.count}" %>
+      </div>
+<% total = @if_then_rules.active.count %>
+<% done  = @if_then_rules.active.count(&:reflected_today?) %>
+<% percent = total.zero? ? 0 : (done * 100 / total) %>
+
+<div class="w-full bg-gray-300 rounded-full h-2 mt-2">
+  <div
+    class="bg-primary h-2 rounded-full transition-all"
+    style="width: <%= percent %>%">
+  </div>
+</div>
+
+<p class="text-xs text-gray-500 mt-1">
+  <%= done %> / <%= total %>
+</p>
 
       <div class="mt-12 flex flex-col gap-3">
         <%= link_to "新しく習慣を作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>


### PR DESCRIPTION

## 概要
- ダッシュボードで今日の達成数を表示
- 今日の達成数に応じたプログレスバーの表示

Close #103 

## 実装内容
### 予定していた作業
- [x] ダッシュボードで今日の達成数を表示


### 予定外だが実施した作業
- [x] プログレスバーの表示
- [x] 一応完了したものの表記を"完了！"ではなく”完了済み"に変更(まだわかりにくいかも?)

## 動作確認
- [x] 今日完了した個数がダッシュボードの下に表示されること
- [x] プログレスバーが機能していること(アニメーションはない最低限) 
<img width="565" height="769" alt="image" src="https://github.com/user-attachments/assets/6cba6495-d935-4b8f-9d98-780197fc3348" />


## 備考
可能なら今後の本リリースでよりスムーズに動くようにしてもいい(turboのイメージ)