### PR TITLE
ダッシュボードの違和感のある部分の修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,30 +7,4 @@ module ApplicationHelper
     else "alert-info"
     end
   end
-
-  def if_then_rule_board_view(rule)
-    safe_join([
-      tag.p(rule.if_condition, class: "font-normal"),
-      tag.p(rule.then_action, class: "font-semibold text-primary mt-4")
-    ])
-  end
-  # 新規作成でその時のactiveなルールの個数でステータスのフォームとしてのデフォルト値を変える
-  def change_default_status(active_if_then_rules, setted_status: nil)
-    # もしすでに設定済みの値があればそれを返す(warningやerrorによる再表示用)
-    return setted_status if setted_status
-    # activeなルールの個数が3つ以上あれば初期値をdraftにする
-    active_if_then_rules.length >= 3 ? "draft" : "active"
-  end
-
-  # 今後以下のような表現方法を切り替える機能があると良いかもしれない
-  # def if_then_rule_board_view(rule, style: :default)
-  # case style
-  # when :default
-  #   "もし#{rule.if_condition}なら、#{rule.then_action}"
-  # when :monologue
-  #   "#{rule.if_condition}になったら、#{rule.then_action}しよう"
-  # when :question
-  #   "#{rule.if_condition}のとき、#{rule.then_action}する？"
-  # end
-  # end
 end

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -1,0 +1,13 @@
+module IfThenRulesHelper
+  def today_progress(if_then_rules)
+    active = if_then_rules.active
+    total  = active.count
+    done   = active.count(&:reflected_today?)
+
+    {
+      total: total,
+      done: done,
+      percent: total.zero? ? 0 : (done * 100 / total)
+    }
+  end
+end

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -1,5 +1,5 @@
 module IfThenRulesHelper
-# ダッシュボードの"今日の達成率"で使用するヘルパー
+  # ダッシュボードの"今日の達成率"で使用するヘルパー
   def today_progress(if_then_rules)
     active = if_then_rules.active
     total  = active.count
@@ -11,7 +11,7 @@ module IfThenRulesHelper
       percent: total.zero? ? 0 : (done * 100 / total)
     }
   end
-# ルールをカード表示する際のヘルパー
+  # ルールをカード表示する際のヘルパー
   def if_then_rule_board_view(rule)
     safe_join([
       tag.p(rule.if_condition, class: "font-normal"),
@@ -19,7 +19,7 @@ module IfThenRulesHelper
     ])
   end
 
-# 新規作成フォームで使うヘルパー
+  # 新規作成フォームで使うヘルパー
   # その時のactiveなルールの個数でstatusの入力欄のデフォルト値を変える
   def change_default_status(active_if_then_rules, setted_status: nil)
     # もしすでに設定済みの値があればそれを返す(warningやerrorによる再表示用)

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -1,4 +1,5 @@
 module IfThenRulesHelper
+# ダッシュボードの"今日の達成率"で使用するヘルパー
   def today_progress(if_then_rules)
     active = if_then_rules.active
     total  = active.count
@@ -9,5 +10,21 @@ module IfThenRulesHelper
       done: done,
       percent: total.zero? ? 0 : (done * 100 / total)
     }
+  end
+# ルールをカード表示する際のヘルパー
+  def if_then_rule_board_view(rule)
+    safe_join([
+      tag.p(rule.if_condition, class: "font-normal"),
+      tag.p(rule.then_action, class: "font-semibold text-primary mt-4")
+    ])
+  end
+
+# 新規作成フォームで使うヘルパー
+  # その時のactiveなルールの個数でstatusの入力欄のデフォルト値を変える
+  def change_default_status(active_if_then_rules, setted_status: nil)
+    # もしすでに設定済みの値があればそれを返す(warningやerrorによる再表示用)
+    return setted_status if setted_status
+    # activeなルールの個数が3つ以上あれば初期値をdraftにする
+    active_if_then_rules.length >= 3 ? "draft" : "active"
   end
 end

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -10,6 +10,7 @@
         <div class="space-y-2">
           <% @if_then_rules.active.each do |rule| %>
             <div class="card bg-base-100 shadow border border-base-300 p-4">
+                <%= link_to "✏️", edit_if_then_rule_path(rule), class: "btn btn-outline  btn-sm " %>
               <%= if_then_rule_board_view(rule) %>
               <% if rule.reflected_today? %>
                 <p>完了済み！</p>
@@ -24,9 +25,7 @@
             </div>
           <% end %>
         </div>
-        <!--<p class="text-sm text-gray-500 mb-2">
-          完了済み <span class="font-normal"><%= "#{@if_then_rules.done.length} " %></span>
-        </p>-->
+
       <% else %>
         <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>
       <% end %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -1,13 +1,11 @@
 <main class="hero min-h-[70vh] bg-base-200">
   <div class="hero-content text-center">
     <div class="max-w-md">
-      <h1 class="text-4xl font-bold mb-4">ダッシュボード</h1>
 
 
       <% if @if_then_rules.any? %>
-        <h2 class="text-lg font-bold ">
-          今日のルール
-        </h2>
+        <h1 class="text-4xl font-bold mb-4">今日のルール</h1>
+
 
         <div class="space-y-2">
           <% @if_then_rules.active.each do |rule| %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -10,7 +10,12 @@
         <div class="space-y-2">
           <% @if_then_rules.active.each do |rule| %>
             <div class="card bg-base-100 shadow border border-base-300 p-4">
-                <%= link_to "✏️", edit_if_then_rule_path(rule), class: "btn btn-outline  btn-sm " %>
+              <div class="flex justify-end mb-2">
+                <%= link_to "✏️",
+                  edit_if_then_rule_path(rule),
+                  class: "btn btn-ghost btn-sm"
+                %>
+              </div>
               <%= if_then_rule_board_view(rule) %>
               <% if rule.reflected_today? %>
                 <p>完了済み！</p>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -35,24 +35,11 @@
             </div>
           <% end %>
         </div>
+
         <!-- カードの下の今日やったルールなどの集計表示 -->
-              <div>
-        <%= "今日やったルールの数:#{@if_then_rules.active.count(&:reflected_today?)}" %>
-      </div>
-<% total = @if_then_rules.active.count %>
-<% done  = @if_then_rules.active.count(&:reflected_today?) %>
-<% percent = total.zero? ? 0 : (done * 100 / total) %>
+        <%= render "if_then_rules/today_progress", progress: today_progress(@if_then_rules) %>
 
-<div class="w-full bg-gray-300 rounded-full h-2 mt-2">
-  <div
-    class="bg-primary h-2 rounded-full transition-all"
-    style="width: <%= percent %>%">
-  </div>
-</div>
 
-<p class="text-xs text-gray-500 mt-1">
-  <%= done %> / <%= total %>
-</p>
 
       <% else %>
         <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -35,13 +35,8 @@
             </div>
           <% end %>
         </div>
-
-      <% else %>
-        <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>
-      <% end %>
-
-
-      <div>
+        <!-- カードの下の今日やったルールなどの集計表示 -->
+              <div>
         <%= "今日やったルールの数:#{@if_then_rules.active.count(&:reflected_today?)}" %>
       </div>
 <% total = @if_then_rules.active.count %>
@@ -58,6 +53,13 @@
 <p class="text-xs text-gray-500 mt-1">
   <%= done %> / <%= total %>
 </p>
+
+      <% else %>
+        <p class="mb-6 text-gray-600">まだ実行中のルールがありません</p>
+      <% end %>
+
+
+
 
       <div class="mt-12 flex flex-col gap-3">
         <%= link_to "新しく習慣を作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -5,37 +5,8 @@
 
       <% if @if_then_rules.active.any? %>
         <h1 class="text-4xl font-bold mb-4">今日のルール</h1>
-
-
-        <div class="space-y-2">
-          <% @if_then_rules.active.each do |rule| %>
-            <div class="card bg-base-100 shadow border border-base-300">
-              <!-- header -->
-              <div class="flex justify-end px-4 pt-2">
-                <%= link_to "✏️",
-                  edit_if_then_rule_path(rule),
-                  class: "btn btn-ghost btn-sm btn-circle"
-                %>
-              </div>
-
-              <!-- body -->
-              <div class="px-4 pb-4 space-y-2">
-                <%= if_then_rule_board_view(rule) %>
-
-                <% if rule.reflected_today? %>
-                  <p>完了済み！</p>
-                <% else %>
-                  <%= button_to "✔️",
-                    if_then_rule_reflections_path(rule),
-                    method: :post,
-                    class: "btn btn-sm btn-outline"
-                  %>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-        </div>
-
+        <!--今日のルール一覧-->
+        <%= render "if_then_rules/today_rules", rules: @if_then_rules %>
         <!-- カードの下の今日やったルールなどの集計表示 -->
         <%= render "if_then_rules/today_progress", progress: today_progress(@if_then_rules) %>
 

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -9,24 +9,29 @@
 
         <div class="space-y-2">
           <% @if_then_rules.active.each do |rule| %>
-            <div class="card bg-base-100 shadow border border-base-300 p-4">
-              <div class="flex justify-end mb-2">
+            <div class="card bg-base-100 shadow border border-base-300">
+              <!-- header -->
+              <div class="flex justify-end px-4 pt-2">
                 <%= link_to "✏️",
                   edit_if_then_rule_path(rule),
-                  class: "btn btn-ghost btn-sm"
+                  class: "btn btn-ghost btn-sm btn-circle"
                 %>
               </div>
-              <%= if_then_rule_board_view(rule) %>
-              <% if rule.reflected_today? %>
-                <p>完了済み！</p>
 
-              <% else %>
-              <%= button_to "✔️",
-                if_then_rule_reflections_path(rule),
-                method: :post,
-                class: "btn btn-sm btn-outline" %>
-              <% end %>
-              
+              <!-- body -->
+              <div class="px-4 pb-4 space-y-2">
+                <%= if_then_rule_board_view(rule) %>
+
+                <% if rule.reflected_today? %>
+                  <p>完了済み！</p>
+                <% else %>
+                  <%= button_to "✔️",
+                    if_then_rule_reflections_path(rule),
+                    method: :post,
+                    class: "btn btn-sm btn-outline"
+                  %>
+                <% end %>
+              </div>
             </div>
           <% end %>
         </div>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -3,7 +3,7 @@
     <div class="max-w-md">
 
 
-      <% if @if_then_rules.any? %>
+      <% if @if_then_rules.active.any? %>
         <h1 class="text-4xl font-bold mb-4">今日のルール</h1>
 
 

--- a/app/views/if_then_rules/_today_progress.html.erb
+++ b/app/views/if_then_rules/_today_progress.html.erb
@@ -1,0 +1,15 @@
+<div>
+  <div>
+    <%= "今日やったルールの数:#{progress[:done]}" %>
+  </div>
+
+  <div class="w-full bg-gray-300 rounded-full h-2 mt-2">
+    <div
+      class="bg-primary h-2 rounded-full transition-all"
+      style="width: <%= progress[:percent] %>%">
+    </div>
+  </div>
+  <p class="text-xs text-gray-500 mt-1">
+    <%= progress[:done] %> / <%= progress[:total] %>
+  </p>
+</div>

--- a/app/views/if_then_rules/_today_rules.html.erb
+++ b/app/views/if_then_rules/_today_rules.html.erb
@@ -1,0 +1,29 @@
+<!--ダッシュボードで使用する今日のルール一覧のパーシャル-->
+<div class="space-y-2">
+  <% rules.active.each do |rule| %>
+    <div class="card bg-base-100 shadow border border-base-300">
+      <!-- header -->
+      <div class="flex justify-end px-4 pt-2">
+        <%= link_to "✏️",
+          edit_if_then_rule_path(rule),
+          class: "btn btn-ghost btn-sm btn-circle"
+        %>
+      </div>
+
+      <!-- body -->
+      <div class="px-4 pb-4 space-y-2">
+        <%= if_then_rule_board_view(rule) %>
+
+        <% if rule.reflected_today? %>
+          <p>完了済み！</p>
+        <% else %>
+          <%= button_to "✔️",
+            if_then_rule_reflections_path(rule),
+            method: :post,
+            class: "btn btn-sm btn-outline"
+          %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION

## 概要
ダッシュボードの違和感のある部分の修正
Close #115 

## 実装内容
### 予定していた作業
- [x] ダッシュボードというh1がおかしいので無くす->これこそ今日のルールにした方が良い？
- [x] ダッシュボードのルールの一覧からそれぞれの詳細を開けるようにする->各カードかタイトル？をリンクへあるいは編集アイコンだけでも
- [x] activeのルールがない時に達成率が表示されてしまうのを修正->activeのルールが存在の時にする



### 予定外だが実施した作業
- [x] ダッシュボードの達成率や今日のリストのパーシャル化（コードが増えてきた上、今後のデザイン統一のため）
- [x] カードのパッディングの調整(右上に編集ボタンを入れる際にやりにくく、今後も崩れにくくするため)
- [x] activeがなくてもdraftのルールがある場合、にactiveがあるものとして表示が分岐していたのを修正 
- [x] application_helper.rbに入っていたif_thenの表示に使うようなヘルパーを適切な位置へ移動 

## 動作確認
ダッシュボードにて
- [x] それぞれの編集画面への導線がある
- [x] activeのルールが一つもない場合に達成率が表示されないこと 
- [x] 表題がダッシュボードにはなっていないこと。 
<img width="346" height="422" alt="image" src="https://github.com/user-attachments/assets/2062806f-6767-4b9b-8ad6-53f4b54744a3" />
<img width="276" height="378" alt="image" src="https://github.com/user-attachments/assets/cceadc0d-1470-4e86-be12-e7e8f6e85847" />


## 備考
編集ボタンはひとまず絵文字にしてある。->あとで一気にアイコンにしたい。デザイン修正系のイシューに含める#122