### PR TITLE
feat:warning_messageをそれぞれのフィールドで分割して表示するように変更

### DIFF
--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -1,11 +1,5 @@
 <!--if_then_rule_formはフォームオブジェクト-->
-<% if_then_rule_form.warning_messages.each do |warning| %>
-  <div class="text-sm text-orange-700">
-    <p><%= warning[:reason] %></p>
-    <p class="text-gray-600"><%= warning[:suggestion] %></p>
-    <p class="text-xs text-gray-500"><%= warning[:example] %></p>
-  </div>
-<% end %>
+
 <%= form_with model: if_then_rule_form, url: url, method: method, class: "max-w-md mx-auto space-y-6" do |f| %>
   <%= f.hidden_field :memo_id %>
   <div class="p-4 rounded-lg bg-blue-50 border border-blue-100">
@@ -21,6 +15,7 @@
       <% end %>
 
     </div>
+    <%= render "if_then_rules/warning_messages", if_then_rule_form: if_then_rule_form, field: :if_condition %>
     <details class="mt-2 group">
       <summary class="text-sm text-gray-500 flex items-center gap-2 cursor-pointer list-none">
         <span class="transition-transform group-open:rotate-90">▶</span>
@@ -48,6 +43,7 @@
       <% end %>
 
     </div>
+    <%= render "if_then_rules/warning_messages", if_then_rule_form: if_then_rule_form, field: :then_action %>
     <details class="mt-2 group">
       <summary class="text-sm text-gray-500 flex items-center gap-2 cursor-pointer list-none">
         <span class="transition-transform group-open:rotate-90">▶</span>
@@ -72,7 +68,8 @@
           </p>
         <% end %>
       <% end %>
-   <p class="text-sm text-gray-500 mt-1">
+  <%= render "if_then_rules/warning_messages", if_then_rule_form: if_then_rule_form, field: :status %>
+  <p class="text-sm text-gray-500 mt-1">
   現在、実行中のルールは <%= @active_if_then_rules.length %> 件です
 </p>
     <div class="pt-4 space-y-3">

--- a/app/views/if_then_rules/_warning_messages.html.erb
+++ b/app/views/if_then_rules/_warning_messages.html.erb
@@ -1,0 +1,7 @@
+<% if_then_rule_form.warning_messages.select{|d| d[:field ]== field}.each do |warning| %>
+  <div class="text-sm text-orange-700">
+    <p><%= warning[:reason] %></p>
+    <p class="text-gray-600"><%= warning[:suggestion] %></p>
+    <p class="text-xs text-gray-500"><%= warning[:example] %></p>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
warningの表示位置をそれぞれのフィールドで分割して表示するように変更
この際にwarningメッセージ表示のパーシャルとして作成。

Close #135 

## 実装内容
### 予定していた作業
- [x] warningの表示位置をそれぞれのフィールドで分割して表示するように変更



### 予定外だが実施した作業
- [x] warningmessageをパーシャルに（今後のデザイン修正のために）

## 動作確認
<img width="1085" height="851" alt="image" src="https://github.com/user-attachments/assets/37904c35-193c-44f5-9bb8-1da2db36dbad" />

- [x] warningがある時に
  - [x] ifの下に対応するwarning_messageが表示されること
  - [x] thenの下に対応するwarning_messageが表示されること
  - [x] statusの下に対応するwarning_messageが表示されること


## 備考
後にする。
- フィールドに文章完成ワーク的なでっかい文字入れるみたいなのもここでしていいかも。
"もしxxxxになったらその時はaaaaaaaする"
の"もし""になったら","する"の部分を最初からある場所にしつつ、
プレースホルダーの例も少しこれに沿ったものに直す？

これをするならば一覧表示のカードみたいなのもパーシャルにした上でこのフレームで統一するのが良さげ

というような感じでデフォルトのフレームを実質的に実装(ビューで文字列)みたいな。

- そもそも内容を整理した方が良い感はある。
"これを気にすると良くなります"みたいな表題つけてwarningの個別のメッセージの意味合いみたいなのを変えるとか？