### PR TITLE
最低限の一通りのながれみたいなものが若干崩れているなどmvpとしての調整

### DIFF
--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -1,6 +1,9 @@
 class IfThenRulesController < ApplicationController
   def index
     @if_then_rules = current_user.if_then_rules.includes(:memo)
+    if @if_then_rules.active.length > 3
+    flash.now[:warning] = "実行中のルールが少し多いかもしれません。(３つまでを推奨していますが現在 #{@if_then_rules.active.length} つです) "
+    end
   end
 
   def show

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -20,7 +20,7 @@ class IfThenRulesController < ApplicationController
     @active_if_then_rules = current_user.if_then_rules.active
 
     if @if_then_rule_form.save(ignore_warnings: params[:commit_type] == "ignore_warnings")
-      redirect_to if_then_rules_path, notice: "If-Thenルールを作成しました"
+      redirect_to @if_then_rule_form.status == "active" ? dash_boards_path : if_then_rules_path, notice: "If-Thenルールを作成しました"
     else
       flash.now[:alert] = "入力内容に問題があります。" if @if_then_rule_form.errors.any?
 

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -28,7 +28,7 @@ class MemosController < ApplicationController
   def update
     @memo = current_user.memos.find(params[:id])
     if @memo.update(memo_params)
-      redirect_to memos_path, notice: "メモの更新が成功しました"
+      redirect_to @memo, notice: "メモの更新が成功しました"
     else
       flash.now[:alert] = "メモの更新が失敗しました"
       render :edit, status: :unprocessable_content

--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -2,7 +2,7 @@ class ReflectionsController < ApplicationController
   include IfThenRulesHelper
   def create
     rule = current_user.if_then_rules.find(params[:if_then_rule_id])
-    
+
     reflection = rule.reflections.find_or_create_by!(
       user: current_user,
       reflected_on: Date.current

--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -1,4 +1,5 @@
 class ReflectionsController < ApplicationController
+  include IfThenRulesHelper
   def create
     rule = current_user.if_then_rules.find(params[:if_then_rule_id])
     
@@ -12,6 +13,12 @@ class ReflectionsController < ApplicationController
       "today_rules",
       partial: "if_then_rules/today_rules",
       locals: { rules: current_user.if_then_rules }
+    )
+
+    streams << turbo_stream.replace(
+      "today_progress",
+      partial: "if_then_rules/today_progress",
+      locals: { progress: today_progress(current_user.if_then_rules) }
     )
 
     if current_user.all_rules_completed_today?
@@ -31,11 +38,19 @@ class ReflectionsController < ApplicationController
   def destroy
   reflection = current_user.reflections.find(params[:id])
   reflection.destroy!
+    streams = []
 
-  render turbo_stream: turbo_stream.replace(
-    "today_rules",
-    partial: "if_then_rules/today_rules",
-    locals: { rules: current_user.if_then_rules }
-  ), notice: "チェックを取り消ししました"
+    streams << turbo_stream.replace(
+      "today_rules",
+      partial: "if_then_rules/today_rules",
+      locals: { rules: current_user.if_then_rules }
+    )
+
+        streams << turbo_stream.replace(
+      "today_progress",
+      partial: "if_then_rules/today_progress",
+      locals: { progress: today_progress(current_user.if_then_rules) }
+    )
+  render turbo_stream: streams, notice: "チェックを取り消ししました"
   end
 end

--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -24,7 +24,18 @@ class ReflectionsController < ApplicationController
     render turbo_stream: streams
   end
 
-    def index
+  def index
     @reflections = current_user.reflections.includes(:if_then_rule).order(reflected_on: :desc)
+  end
+
+  def destroy
+  reflection = current_user.reflections.find(params[:id])
+  reflection.destroy!
+
+  render turbo_stream: turbo_stream.replace(
+    "today_rules",
+    partial: "if_then_rules/today_rules",
+    locals: { rules: current_user.if_then_rules }
+  ), notice: "チェックを取り消ししました"
   end
 end

--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -6,10 +6,22 @@ class ReflectionsController < ApplicationController
       user: current_user,
       reflected_on: Date.current
       )
+    streams = []
+
+    streams << turbo_stream.replace(
+      "today_rules",
+      partial: "if_then_rules/today_rules",
+      locals: { rules: current_user.if_then_rules }
+    )
+
     if current_user.all_rules_completed_today?
-    flash[:celebrate] = "おめでとうございます!今日のマイルール、すべて達成しました!"
+      streams << turbo_stream.replace(
+        "modal",
+        partial: "shared/celebrate_modal"
+      )
     end
-      redirect_back fallback_location: dash_boards_path
+
+    render turbo_stream: streams
   end
 
     def index

--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -1,12 +1,15 @@
 class ReflectionsController < ApplicationController
   def create
     rule = current_user.if_then_rules.find(params[:if_then_rule_id])
-
+    
     reflection = rule.reflections.find_or_create_by!(
       user: current_user,
       reflected_on: Date.current
-    )
-    redirect_back fallback_location: dash_boards_path
+      )
+    if current_user.all_rules_completed_today?
+    flash[:celebrate] = "おめでとうございます!今日のマイルール、すべて達成しました!"
+    end
+      redirect_back fallback_location: dash_boards_path
   end
 
     def index

--- a/app/javascript/controllers/celebrate_modal_controller.js
+++ b/app/javascript/controllers/celebrate_modal_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="celebrate-modal"
+export default class extends Controller {
+  close() {
+    this.element.remove()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import CelebrateModalController from "./celebrate_modal_controller"
+application.register("celebrate-modal", CelebrateModalController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -15,4 +15,12 @@ class IfThenRule < ApplicationRecord
   def today_reflection
     reflections.find_by(reflected_on: Date.current)
   end
+
+  def human_status
+    case status
+    when "draft" then "下書き"
+    when "active" then "実行中"
+    when "done" then "完了"
+    end
+  end
 end

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -3,7 +3,7 @@ class IfThenRule < ApplicationRecord
   belongs_to :memo
   has_many :reflections, dependent: :destroy
 
-  enum status: { draft: 0, active: 1, done: 2 }
+  enum status: { draft: 0, active: 1, habituated: 2 }
   validates :if_condition, presence: true, if: :active?
   validates :then_action, presence: true, if: :active?
   validates :status, presence: true
@@ -20,7 +20,7 @@ class IfThenRule < ApplicationRecord
     case status
     when "draft" then "下書き"
     when "active" then "実行中"
-    when "done" then "完了"
+    when "habituated" then "定着済み"
     end
   end
 end

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -11,4 +11,8 @@ class IfThenRule < ApplicationRecord
   def reflected_today?
   reflections.exists?(reflected_on: Date.current)
   end
+
+  def today_reflection
+    reflections.find_by(reflected_on: Date.current)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,9 @@ class User < ApplicationRecord
   validates :password_confirmation,
             presence: true,
             if: -> { new_record? || will_save_change_to_crypted_password? }
+
+  def  all_rules_completed_today?
+    today_rules = if_then_rules.active
+    completed = today_rules.all?(&:reflected_today?)
+  end
 end

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -32,6 +32,7 @@
     <% content_for :title do %>
       こちらがダッシュボードです。
     <% end %>
+    <p class="mb-6 text-gray-600">ここで毎日の振り返りで実行したルールのチェックをします</p>
     <p class="mb-6 text-gray-600">まだ実行中のルールがありません。新しく作ってみましょう</p>
     <div class="mt-12 flex flex-col gap-3">
       <%= link_to "新しく習慣を作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -11,7 +11,9 @@
     <%= render "if_then_rules/today_rules", rules: @if_then_rules %>
     </turbo-frame>
     <!-- カードの下の今日やったルールなどの集計表示 -->
+    <turbo-frame id="today_progress">
     <%= render "if_then_rules/today_progress", progress: today_progress(@if_then_rules) %>
+    </turbo-frame>
 
     <div class="mt-6 flex flex-col gap-3">
       <%= link_to "新しく習慣を作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -7,7 +7,9 @@
       今日のルール
     <% end %>
     <!--今日のルール一覧-->
+    <turbo-frame id="today_rules">
     <%= render "if_then_rules/today_rules", rules: @if_then_rules %>
+    </turbo-frame>
     <!-- カードの下の今日やったルールなどの集計表示 -->
     <%= render "if_then_rules/today_progress", progress: today_progress(@if_then_rules) %>
 

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -56,7 +56,7 @@
     </details>
   </div>
    <%= f.label :status, "状態", class: "label" %>
-   <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"],["完了", "done"]], {selected: change_default_status(@active_if_then_rules,setted_status:if_then_rule_form.status)} %>
+   <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"],["定着済み", "habituated"]], {selected: change_default_status(@active_if_then_rules,setted_status:if_then_rule_form.status)} %>
 
 
 <% if if_then_rule_form.warnings.any? %>

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -56,7 +56,7 @@
     </details>
   </div>
    <%= f.label :status, "状態", class: "label" %>
-   <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"]], {selected: change_default_status(@active_if_then_rules,setted_status:if_then_rule_form.status)} %>
+   <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"],["完了", "done"]], {selected: change_default_status(@active_if_then_rules,setted_status:if_then_rule_form.status)} %>
 
 
 <% if if_then_rule_form.warnings.any? %>

--- a/app/views/if_then_rules/_today_progress.html.erb
+++ b/app/views/if_then_rules/_today_progress.html.erb
@@ -1,3 +1,4 @@
+<turbo-frame id="today_progress">
 <div>
   <div>
     <%= "今日やったルールの数:#{progress[:done]}" %>
@@ -13,3 +14,4 @@
     <%= progress[:done] %> / <%= progress[:total] %>
   </p>
 </div>
+</turbo-frame>

--- a/app/views/if_then_rules/_today_rules.html.erb
+++ b/app/views/if_then_rules/_today_rules.html.erb
@@ -7,7 +7,8 @@
       <div class="flex justify-end px-4 pt-2">
         <%= link_to "✏️",
           edit_if_then_rule_path(rule),
-          class: "btn btn-ghost btn-sm btn-circle"
+          class: "btn btn-ghost btn-sm btn-circle",
+          data: { turbo_frame: "_top" }
         %>
       </div>
 

--- a/app/views/if_then_rules/_today_rules.html.erb
+++ b/app/views/if_then_rules/_today_rules.html.erb
@@ -1,7 +1,7 @@
 <!--ダッシュボードで使用する今日のルール一覧のパーシャル-->
 <div class="space-y-2">
   <% rules.active.each do |rule| %>
-    <div class="bg-[#eaf2fb] card shadow-md rounded-lg p-4">
+    <div class=" <%= rule.reflected_today? ? "bg-success/80 " : "bg-[#eaf2fb]" %> card shadow-md rounded-lg p-4">
       <!-- header -->
       <div class="flex justify-end px-4 pt-2">
         <%= link_to "✏️",

--- a/app/views/if_then_rules/_today_rules.html.erb
+++ b/app/views/if_then_rules/_today_rules.html.erb
@@ -1,4 +1,5 @@
 <!--ダッシュボードで使用する今日のルール一覧のパーシャル-->
+<turbo-frame id="today_rules">
 <div class="space-y-2">
   <% rules.active.each do |rule| %>
     <div class=" <%= rule.reflected_today? ? "bg-success/80 " : "bg-[#eaf2fb]" %> card shadow-md rounded-lg p-4">
@@ -27,3 +28,4 @@
     </div>
   <% end %>
 </div>
+</turbo-frame>

--- a/app/views/if_then_rules/_today_rules.html.erb
+++ b/app/views/if_then_rules/_today_rules.html.erb
@@ -17,6 +17,11 @@
 
         <% if rule.reflected_today? %>
           <p>完了済み！</p>
+          <%= button_to "取り消す",
+            if_then_rule_reflection_path(rule,rule.today_reflection.id),
+            method: :delete,
+            class: "btn btn-xs"
+          %>
         <% else %>
           <%= button_to "✔️",
             if_then_rule_reflections_path(rule),

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -66,6 +66,12 @@
     <p class="text-gray-500">
       まだIf-Thenルールはありません。
     </p>
+    <p class="text-gray-500">
+    まずは一つメモやルールを作ることから始めましょう。
+    </p>
+    <div class="mt-12 flex flex-col gap-3">
+      <%= link_to "新しくルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
+    </div>
   <% end %>
 
 </div>

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -25,7 +25,7 @@
             </p>
             <div>
               <p class="tag bg-accent text-white inline-block mr-2 px-2.5 py-0.5">
-                <%= rule.status %>
+                <%= rule.human_status%>
               </p>
             </div>
 

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -1,11 +1,7 @@
     <% content_for :title do %>
       If-Thenルール一覧
     <% end %>
-<% if @if_then_rules.active.count > 3 %>
-  <p class="text-sm text-yellow-600 mb-2">
-    実行中のルールが少し多いかもしれません。<%= "(３つまでを推奨していますが現在 #{@if_then_rules.active.length} つです) " %>
-  </p>
-<% end %>
+
 
 <div class="max-w-1vw">
 

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -65,9 +65,9 @@
     <p class="text-gray-500">
     まずは一つメモやルールを作ることから始めましょう。
     </p>
+  <% end %>
     <div class="mt-12 flex flex-col gap-3">
       <%= link_to "新しくルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
     </div>
-  <% end %>
 
 </div>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -25,7 +25,7 @@
 
       <div>
         <p class="tag bg-accent text-white inline">
-          <%= @if_then_rule.status %>
+          <%= @if_then_rule.human_status %>
         </p>
       </div>
       <div class="card-actions justify-end">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
       <%= render "shared/header_guest" %>
     <% end %>
 
-
+<turbo-frame id="modal"></turbo-frame>
 
     <div class ="bg-[#69c5d4] min-h-[70vh] space-y-6 ">
       <% flash.each do |type, message| %>

--- a/app/views/memos/edit.html.erb
+++ b/app/views/memos/edit.html.erb
@@ -30,7 +30,7 @@
 
         <!-- ボタン -->
         <div class="flex justify-between">
-          <%= link_to "戻る", memos_path, class: "btn btn-ghost" %>
+          <%= link_to "一覧へ", memos_path, class: "btn btn-ghost" %>
 
           <div class="flex gap-2">
             <%= f.submit "更新する", class: "btn btn-primary" %>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -52,6 +52,13 @@
       </div>
   <% else %>
     <div class="text-center text-base-content/60">
+
+      <p class="mb-4">メモでは日々の生活の"うまく行く工夫"や"気づき"を書いておきます</p>
+      <p class="mb-2 text-xs">	
+      ex:朝水を飲むと頭がスッキリする</p>
+      <p class="mb-4 text-xs">	
+	    作業前に5分準備すると集中できる など</p>
+      <p class="mb-4">そのメモをもとにマイルールを作ります</p>
       <p class="mb-4">まだメモがありません</p>
       <%= link_to "最初のメモを作成する",
             new_memo_path,

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -25,7 +25,7 @@
       <%= f.text_area :body,
             rows: 6,
             class: "textarea textarea-bordered w-full",
-            placeholder: "目標やこうすると良いことがあるという工夫などを自由に書いてください" %>
+            placeholder: "目標やこうすると良いことがあるという工夫などを自由に書いてください これは後で'マイルール'を作るきっかけとして使います" %>
 
       <% if @memo.errors[:body].any? %>
         <p class="text-error text-sm mt-1">

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -14,7 +14,7 @@
 
     <!-- 編集・削除 -->
     <div class="flex gap-4">
-      <%= link_to "戻る", memos_path, class: "btn btn-ghost" %>
+      <%= link_to "一覧へ", memos_path, class: "btn btn-ghost" %>
       <%= link_to "編集",
                   edit_memo_path(@memo),
                   class: "btn btn-outline btn-primary" %>

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -4,15 +4,27 @@
 <div class="max-w-md">
 
 <ul>
-<% @reflections.group_by(&:reflected_on).each do |date, reflections| %>
-  <h2 class="text-lg font-semibold mt-4 mb-2"><%= date.strftime("%Y年%-m月%-d日") %></h2>
-  <ul class="space-y-2">
-    <% reflections.each do |reflection| %>
-      <li class="bg-[#eaf2fb] card shadow-md rounded-lg p-4">
-        <%= if_then_rule_board_view(reflection.if_then_rule) %>
-      </li>
-    <% end %>
-  </ul>
+<% if  @reflections.any?%>
+  <% @reflections.group_by(&:reflected_on).each do |date, reflections| %>
+    <h2 class="text-lg font-semibold mt-4 mb-2"><%= date.strftime("%Y年%-m月%-d日") %></h2>
+    <ul class="space-y-2">
+      <% reflections.each do |reflection| %>
+        <li class="bg-[#eaf2fb] card shadow-md rounded-lg p-4">
+          <%= if_then_rule_board_view(reflection.if_then_rule) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+<% else %>
+    <p class="text-gray-500">
+      まだ振り返りはありません。
+    </p>
+    <p class="text-gray-500">
+    まずは一つメモやルールを作ることから始めましょう。
+    </p>
+    <div class="mt-12 flex flex-col gap-3">
+      <%= link_to "新しくルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
+    </div>
 <% end %>
 
 </div>

--- a/app/views/shared/_celebrate_modal.html.erb
+++ b/app/views/shared/_celebrate_modal.html.erb
@@ -1,0 +1,8 @@
+<div data-controller="celebrate-modal" class="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+  <div class="bg-white rounded-xl p-6 z-[60]">
+    <h2 class="text-xl font-bold">🎉 完了！</h2>
+    <p>今日のマイルールをすべて達成しました</p>
+
+    <button data-action="celebrate-modal#close" class="btn mt-4">閉じる</button>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   resources :memos
   # ifthenの表示機能->if_then_rules
   resources :if_then_rules, only: %i[ index show new create edit update destroy] do
-    resources :reflections, only: %i[create]
+    resources :reflections, only: %i[create destroy]
   end
   # ifthenの作成機能(ステップUI)->if_then_rules/flows
   namespace :if_then_rules do

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe IfThenRule, type: :model do
   end
 
   describe "バリデーションstatus" do
+    let(:rule) { create(:if_then_rule, user: user, memo: memo) }
     it "statusがnilの場合invalidになる" do
       if_then_rule = build(:if_then_rule, user: user, memo: memo, status: nil)
 
@@ -42,28 +43,82 @@ RSpec.describe IfThenRule, type: :model do
       expect(if_then_rule.errors[:status]).to include("can't be blank")
     end
   end
-
-  describe "#reflected_today?メソッドの確認" do
+  describe "便利系メソッド関連" do
     let(:rule) { create(:if_then_rule, user: user, memo: memo) }
 
-    context "今日のreflectionがある場合" do
-      before do
-        create(:reflection,
-          user: user,
-          if_then_rule: rule,
-          reflected_on: Date.current
-        )
+
+    describe "#reflected_today?" do
+      context "今日のreflectionがある場合" do
+        before do
+          create(:reflection,
+            user: user,
+            if_then_rule: rule,
+            reflected_on: Date.current
+          )
+        end
+
+        it "trueを返す" do
+          expect(rule.reflected_today?).to be true
+        end
       end
 
-      it "trueを返す" do
-        expect(rule.reflected_today?).to be true
+      context "今日のreflectionがない場合" do
+        it "falseを返す" do
+          expect(rule.reflected_today?).to be false
+        end
       end
     end
 
-    context "今日のreflectionがない場合" do
-      it "falseを返す" do
-        expect(rule.reflected_today?).to be false
+
+    describe "#today_reflection" do
+
+      context "今日のreflectionがある場合" do
+        before do
+          create(:reflection,
+            user: user,
+            if_then_rule: rule,
+            reflected_on: Date.current
+          )
+        end
+
+        it "オブジェクトを返す" do
+          expect(rule.today_reflection).to be_present
+        end
       end
+
+      context "今日のreflectionがない場合" do
+        it "nilを返す" do
+          expect(rule.today_reflection).to be nil
+        end
+      end
+    end
+
+
+    describe "#human_status" do
+        context "status が draft のとき" do
+    before { rule.update!(status: :draft) }
+
+    it "下書き を返す" do
+      expect(rule.human_status).to eq "下書き"
+    end
+  end
+
+  context "status が active のとき" do
+    before { rule.update!(status: :active) }
+
+    it "実行中 を返す" do
+      expect(rule.human_status).to eq "実行中"
+    end
+  end
+
+  context "status が habituated のとき" do
+    before { rule.update!(status: :habituated) }
+
+    it "定着済み を返す" do
+      expect(rule.human_status).to eq "定着済み"
+    end
+  end
+
     end
   end
 end

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe IfThenRule, type: :model do
 
 
     describe "#today_reflection" do
-
       context "今日のreflectionがある場合" do
         before do
           create(:reflection,
@@ -118,7 +117,6 @@ RSpec.describe IfThenRule, type: :model do
       expect(rule.human_status).to eq "定着済み"
     end
   end
-
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -77,4 +77,37 @@ RSpec.describe User, type: :model do
     expect(user.salt).to be_present
     end
   end
+
+  describe "#all_rules_completed_today?" do
+    let(:user) { create(:user) }
+    let(:memo) { create(:memo, user: user) }
+    context "すべてのactiveルールが今日完了しているとき" do
+      it "trueを返す" do
+        rule1 = create(:if_then_rule, user: user, memo: memo, status: :active)
+        rule2 = create(:if_then_rule, user: user, memo: memo, status: :active)
+
+        create(:reflection, user: user,  if_then_rule: rule1, reflected_on: Date.current)
+        create(:reflection, user: user,  if_then_rule: rule2, reflected_on: Date.current)
+
+        expect(user.all_rules_completed_today?).to eq true
+      end
+    end
+
+    context "activeルールの一部が未完了のとき" do
+      it "falseを返す" do
+        rule1 = create(:if_then_rule, user: user, memo: memo, status: :active)
+        rule2 = create(:if_then_rule, user: user, memo: memo, status: :active)
+
+        create(:reflection, user: user,  if_then_rule: rule1, reflected_on: Date.current)
+
+        expect(user.all_rules_completed_today?).to eq false
+      end
+    end
+
+    context "activeルールが存在しないとき" do
+      it "trueを返す" do
+        expect(user.all_rules_completed_today?).to eq true
+      end
+    end
+  end
 end

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Memos", type: :request do
         memo: { title: "更新後タイトル" }
       }
 
-      expect(response).to redirect_to(memos_path)
+      expect(response).to redirect_to(memo_path(memo))
       expect(memo.reload.title).to eq("更新後タイトル")
     end
   end


### PR DESCRIPTION

## 概要
最低限の一通りのながれみたいなものが若干崩れているなどmvpとしての調整
最終調整の予定だったがとてもではないがこんな状態では出せないのでもう少し
別のイシューとして調整を入れる

Close #141 

## 実装内容
### 予定していた作業
- [x] 何もないところから新規作成という導線で考えた時に誤ってdraft(not_active)にしてしまったらルールがあたかも作れなかったかのようになってしまうのをどうにかするべき
- [x] データ上ではDoneがあるのに実際のところDoneにすることができないので編集としてでもいいので一応アプリの機能からDoneにできるようにした方が良い。
- [x] ifthenルールの一覧表示の際のエラー表示がおかしくなっている.


### 予定外だが実施した作業
- [x]  memo編集時のリダイレクト先を詳細画面に変更
- [x]  ifthenruleの編集時にactiveを作った時リダイレクト先をダッシュボードに変更
- [x]  ifthenルール一覧にて既にデータがあっても新規作成はあって良い
- [x]  ifthenルール一覧の4つを超えている時の注意が変な位置に出てくるのをフラッシュメッセージにしてみるべき
- [x]  ifthenとreflectionの一覧において0の時の表示をすること
- [x]  draftやactiveというタグは意味不明なのでやめること
- [x]  チェックに時の反応がなさ過ぎて意味不明なのでもっと何かつけること
    - [x]  1つチェック時にカードの色が変わること
    - [x]  その日のもの全てのチェック時にモーダルを出す
- [x]  チェックしたものを戻せない問題

## 動作確認
- [x] ダッシュボードでその日全ての機能がチェックされたらモーダルで通知する 
<a href="https://gyazo.com/04a3304ab3823412f8e8389ebc441bbd"><img src="https://i.gyazo.com/04a3304ab3823412f8e8389ebc441bbd.gif" alt="Image from Gyazo" width="600"/></a>
- [x]  ダッシュボードでチェックのキャンセルができること
- [x]  各所の補足をつけたり、リダイレクト先を調整して導線を整えたり 表示の修正

## 備考
 ダッシュボードではreflections_controllerを介しながらturbo_streamやturbo_frameを使用しているが、まだ汚い感じなので直した方がいい
またモーダルを消すところでstimulusを使用している