### PR TITLE
Feat/Rule編集時に memo を変更可能にする

### DIFF
--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -3,4 +3,10 @@ class Memo < ApplicationRecord
   has_many :if_then_rules, dependent: :nullify
   validates :title, presence: :true, length: { maximum: 100 }
   validates :body, length: { maximum: 10_000 }
+
+  def display_for_select
+    title_text = title.present? ? title.truncate(10) : "（無題）"
+    body_text = body.present? ? body.truncate(10) : "(本文はありません)"
+    "#{title_text}：#{body_text}"
+  end
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -5,8 +5,8 @@ class Memo < ApplicationRecord
   validates :body, length: { maximum: 10_000 }
 
   def display_for_select
-    title_text = title.present? ? title.truncate(10) : "（無題）"
-    body_text = body.present? ? body.truncate(10) : "(本文はありません)"
-    "#{title_text}：#{body_text}"
+    title_text = title.present? ? title.truncate(20) : "（無題）"
+    body_text = body.presence&.truncate(10)
+    "#{title_text} - #{body_text}"
   end
 end

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -76,6 +76,10 @@
             class: "toggle toggle-primary" %>
       <span class="text-sm">ヒントの自動チェックをしない</span>
     </label>
+    <% if controller.action_name == "edit" %>
+      <p class="text-xs text-gray-400 mb-1">メモを変更する</p>
+      <%= f.collection_select :memo_id, current_user.memos, :id, :title, include_blank: true, selected: @memo.id %>
+    <% end %>
 
     <!--保存ボタンなど-->
     <div class="pt-4 space-y-3">
@@ -92,15 +96,13 @@
                     class: "btn btn-primary w-full" %>
       <% end %>
     </div>
-      <% if controller.action_name == "edit" %>
-        <%= f.collection_select :memo_id, current_user.memos, :id, :title, include_blank: true, selected: @memo.id %>
-      <% end %>
+
     <% end %>
     <!--フォームここまで-->
     <!--選択されているメモの表示-->
     <% if @memo %>
       <div class="bg-memo p-3 rounded text-sm">
-        <p class="text-xs text-gray-400 mb-1">元メモ</p>
+        <p class="text-xs text-gray-400 mb-1">現在のメモ</p>
         <%= @memo.title %>
         <%= @memo.body %>
       </div>

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -92,7 +92,9 @@
                     class: "btn btn-primary w-full" %>
       <% end %>
     </div>
-
+      <%if controller.action_name == "edit" %>
+        <%= f.collection_select :memo_id, Memo.all, :id, :title, include_blank: true, selected: @memo.id %>
+      <% end %>
     <% end %>
     <!--フォームここまで-->
     <!--選択されているメモの表示-->

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -93,7 +93,7 @@
       <% end %>
     </div>
       <% if controller.action_name == "edit" %>
-        <%= f.collection_select :memo_id, Memo.all, :id, :title, include_blank: true, selected: @memo.id %>
+        <%= f.collection_select :memo_id, current_user.memos, :id, :title, include_blank: true, selected: @memo.id %>
       <% end %>
     <% end %>
     <!--フォームここまで-->

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -78,7 +78,7 @@
     </label>
     <% if controller.action_name == "edit" %>
       <p class="text-xs text-gray-400 mb-1">メモを変更する</p>
-      <%= f.collection_select :memo_id, current_user.memos, :id, :display_for_select, include_blank: true, selected: @memo.id %>
+      <%= f.collection_select :memo_id, current_user.memos, :id, :display_for_select, include_blank: true %>
     <% end %>
 
     <!--保存ボタンなど-->

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -72,7 +72,7 @@
     <label class="flex items-center gap-2">
       <%= check_box_tag :commit_type,
             "ignore_warnings",
-            false,
+            controller.action_name == "edit" ? true : false,
             class: "toggle toggle-primary" %>
       <span class="text-sm">ヒントの自動チェックをしない</span>
     </label>
@@ -92,7 +92,7 @@
                     class: "btn btn-primary w-full" %>
       <% end %>
     </div>
-      <%if controller.action_name == "edit" %>
+      <% if controller.action_name == "edit" %>
         <%= f.collection_select :memo_id, Memo.all, :id, :title, include_blank: true, selected: @memo.id %>
       <% end %>
     <% end %>

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -78,7 +78,7 @@
     </label>
     <% if controller.action_name == "edit" %>
       <p class="text-xs text-gray-400 mb-1">メモを変更する</p>
-      <%= f.collection_select :memo_id, current_user.memos, :id, :title, include_blank: true, selected: @memo.id %>
+      <%= f.collection_select :memo_id, current_user.memos, :id, :display_for_select, include_blank: true, selected: @memo.id %>
     <% end %>
 
     <!--保存ボタンなど-->

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe Memo, type: :model do
   let(:user) { User.create }
   describe "バリデーション" do
-
     it "title があれば有効" do
       memo = build(:memo, title: "テストメモ", user: user)
       expect(memo).to be_valid

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Memo, type: :model do
+  let(:user) { User.create }
   describe "バリデーション" do
-    let(:user) { User.create }
 
     it "title があれば有効" do
       memo = build(:memo, title: "テストメモ", user: user)
@@ -18,6 +18,25 @@ RSpec.describe Memo, type: :model do
     it "title が100文字を超えると無効" do
       memo = build(:memo, title: "a" * 101, user: user)
       expect(memo).not_to be_valid
+    end
+  end
+  describe "#display_for_select" do
+    it "titleとbodyを結合して表示する" do
+      memo = build(:memo, title: "タイトル", body: "本文")
+
+      expect(memo.display_for_select).to eq("タイトル - 本文")
+    end
+
+    it "titleがない場合は無題になる" do
+      memo = build(:memo, title: nil, body: "本文")
+
+      expect(memo.display_for_select).to start_with("（無題）")
+    end
+
+    it "bodyがnilでもエラーにならずハイフンだけ残る" do
+      memo = build(:memo, title: "タイトル", body: nil)
+
+      expect(memo.display_for_select).to end_with(" - ")
     end
   end
 end


### PR DESCRIPTION
## 概要
Rule編集時に memo を変更可能にする

Close #164 

## 実装内容
### 予定していた作業
- [x] 編集時の"action_name"を使用してeditの時だけメモの編集のセレクトボックスが出てくる
 - [x] このときパーシャルになっているのでその部分は渡す必要があれば渡す(不要)

  - [x] select box を追加`collection_select`
    - [x] メモなしもできるように、include_blankも含める
    - [x] その時のルールの紐付けに合わせてこのセレクトの初期値は合わせる

- [x] 編集時はwarnings機能を動かさないように"無視する"トグルの初期値をonにする
action_nameやcontroller_nameが使える？




### 予定外だが実施した作業
- [x] memoにセレクトのタイトルを表示するためのメソッド追加`#display_for_select"`（メモのタイトルが今後nilになったとしても分かりやすくするため）

## 動作確認
- [x] 編集時のみに新たなメモとの紐付けができること(newの時は出てこない)
  - [x] ひとまずは既存のメモの選択のみにすること(その場で新規メモはつくらない)
- [x] メモは無しでもそのままいけること
- [x] 編集時のトグルの初期値がonであること


## 備考
セレクトボックスで選択されているものに応じて"下にあるメモ表示"を反映させてもいいかもしれないが、行うとしたらstimulus
になる可能性がある？(一旦今回はやらない方向)