### PR TITLE
Feat/メモとルールの作成のステップ数のナビゲーションの追加

### DIFF
--- a/app/controllers/if_then_rules/flows_controller.rb
+++ b/app/controllers/if_then_rules/flows_controller.rb
@@ -1,7 +1,7 @@
 class IfThenRules::FlowsController < ApplicationController
   def step1
      @memos = current_user.memos.order(created_at: :desc)
-     @step = :step1
+     @step = 1
   end
 
   # def step1_submit

--- a/app/controllers/if_then_rules/flows_controller.rb
+++ b/app/controllers/if_then_rules/flows_controller.rb
@@ -1,6 +1,7 @@
 class IfThenRules::FlowsController < ApplicationController
   def step1
      @memos = current_user.memos.order(created_at: :desc)
+     @step = :step1
   end
 
   # def step1_submit

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -14,6 +14,7 @@ class IfThenRulesController < ApplicationController
     @if_then_rule_form = IfThenRuleForm.new({ memo_id: params[:memo_id] }, user: current_user)
     @active_if_then_rules = current_user.if_then_rules.active
     @memo = Memo.find_by(id: @if_then_rule_form.memo_id)
+    @step = :step2
   end
 
   def create

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -21,7 +21,7 @@ class IfThenRulesController < ApplicationController
     @if_then_rule_form = IfThenRuleForm.new(if_then_rule_params, user: current_user)
     @active_if_then_rules = current_user.if_then_rules.active
     @memo = Memo.find_by(id: @if_then_rule_form.memo_id)
-
+    @step = 2
     if @if_then_rule_form.save(ignore_warnings: params[:commit_type] == "ignore_warnings")
       redirect_to @if_then_rule_form.status == "active" ? dash_boards_path : if_then_rules_path, notice: "If-Thenルールを作成しました"
     else

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -14,7 +14,7 @@ class IfThenRulesController < ApplicationController
     @if_then_rule_form = IfThenRuleForm.new({ memo_id: params[:memo_id] }, user: current_user)
     @active_if_then_rules = current_user.if_then_rules.active
     @memo = Memo.find_by(id: @if_then_rule_form.memo_id)
-    @step = :step2
+    @step = 2
   end
 
   def create

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -5,6 +5,8 @@ class MemosController < ApplicationController
 
   def new
     @memo = current_user.memos.build
+    @from_rule_flow = params[:from] == "rule_flow"
+
   end
 
   def create

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -11,6 +11,7 @@ class MemosController < ApplicationController
 
   def create
     @memo = current_user.memos.build(memo_params)
+    @from_rule_flow = params[:memo][:from] == "rule_flow"
     if @memo.save
       redirect_to @memo, notice: "メモの作成が成功しました"
     else
@@ -47,7 +48,7 @@ class MemosController < ApplicationController
   def memo_params
     params.require(:memo).permit(
       :title,
-      :body
+      :body,
     )
   end
 end

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -13,7 +13,7 @@ class MemosController < ApplicationController
     @memo = current_user.memos.build(memo_params)
     @from_rule_flow = params[:memo][:from] == "rule_flow"
     if @memo.save
-      redirect_to @memo, notice: "メモの作成が成功しました"
+      redirect_to memo_path(@memo, from: "rule_flow"), notice: "メモの作成が成功しました"
     else
       flash.now[:alert] = "メモの作成が失敗しました"
       render :new, status: :unprocessable_content
@@ -22,6 +22,7 @@ class MemosController < ApplicationController
 
   def show
     @memo = current_user.memos.find(params[:id])
+    @from_rule_flow = params[:from] == "rule_flow"
   end
 
   def edit

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -6,7 +6,6 @@ class MemosController < ApplicationController
   def new
     @memo = current_user.memos.build
     @from_rule_flow = params[:from] == "rule_flow"
-
   end
 
   def create

--- a/app/views/if_then_rules/_flow_navigation.html.erb
+++ b/app/views/if_then_rules/_flow_navigation.html.erb
@@ -1,0 +1,4 @@
+<ul class="steps">
+  <li class="step <%= "step-primary" if step == :step1 %>">1.メモ選択</li>
+  <li class="step <%= "step-primary" if step == :step2 %>">2.ルール作成</li>
+</ul>

--- a/app/views/if_then_rules/_flow_navigation.html.erb
+++ b/app/views/if_then_rules/_flow_navigation.html.erb
@@ -1,4 +1,4 @@
 <ul class="steps">
-  <li class="step <%= "step-primary" if step >= 1 %> animate-fade-in ">1.メモ選択</li>
+  <li class="step <%= "step-primary" if step >= 1 %> ">1.メモ選択</li>
   <li class="step <%= "step-primary" if step >= 2 %>">2.if-thenでルールの作成</li>
 </ul>

--- a/app/views/if_then_rules/_flow_navigation.html.erb
+++ b/app/views/if_then_rules/_flow_navigation.html.erb
@@ -1,4 +1,4 @@
 <ul class="steps">
   <li class="step <%= "step-primary" if step == :step1 %>">1.メモ選択</li>
-  <li class="step <%= "step-primary" if step == :step2 %>">2.ルール作成</li>
+  <li class="step <%= "step-primary" if step == :step2 %>">2.if-thenでルールの作成</li>
 </ul>

--- a/app/views/if_then_rules/_flow_navigation.html.erb
+++ b/app/views/if_then_rules/_flow_navigation.html.erb
@@ -1,4 +1,4 @@
 <ul class="steps">
-  <li class="step <%= "step-primary" if step == :step1 %>">1.メモ選択</li>
-  <li class="step <%= "step-primary" if step == :step2 %>">2.if-thenでルールの作成</li>
+  <li class="step <%= "step-primary" if step >= 1 %> animate-fade-in ">1.メモ選択</li>
+  <li class="step <%= "step-primary" if step >= 2 %>">2.if-thenでルールの作成</li>
 </ul>

--- a/app/views/if_then_rules/flows/step1.html.erb
+++ b/app/views/if_then_rules/flows/step1.html.erb
@@ -38,6 +38,6 @@
 
 もしくは
   <div class="mt-12 flex flex-col gap-3">
-    <%= link_to "新しくメモを作成する", new_memo_path, class:"btn btn-primary" %>
+    <%= link_to "新しくメモを作成する", new_memo_path(from: "rule_flow"), class:"btn btn-primary" %>
   </div>
 

--- a/app/views/if_then_rules/flows/step1.html.erb
+++ b/app/views/if_then_rules/flows/step1.html.erb
@@ -5,7 +5,7 @@
 <div class="relative">
   <%= link_to '← ダッシュボードに戻る',
       dash_boards_path,
-      class: 'btn btn-ghost btn-sm text-gray-500' %>
+      class: 'btn btn-ghost btn-sm ' %>
 </div>
 <%= render "if_then_rules/flow_navigation", step: @step %>
   <p class="mb-6 text-gray-600">

--- a/app/views/if_then_rules/flows/step1.html.erb
+++ b/app/views/if_then_rules/flows/step1.html.erb
@@ -2,7 +2,11 @@
 <% content_for :title do %>
       マイルールの作成
 <% end %>
-
+<div class="relative">
+  <%= link_to '← ダッシュボードに戻る',
+      dash_boards_path,
+      class: 'btn btn-ghost btn-sm text-gray-500' %>
+</div>
 <%= render "if_then_rules/flow_navigation", step: @step %>
   <p class="mb-6 text-gray-600">
   元にするメモを選択してください

--- a/app/views/if_then_rules/flows/step1.html.erb
+++ b/app/views/if_then_rules/flows/step1.html.erb
@@ -3,7 +3,7 @@
       ステップ１-メモの選択
 <% end %>
 
-
+<%= render "if_then_rules/flow_navigation", step: @step %>
   <p class="mb-6 text-gray-600">
   元にするメモを選択してください
   </p>

--- a/app/views/if_then_rules/flows/step1.html.erb
+++ b/app/views/if_then_rules/flows/step1.html.erb
@@ -1,6 +1,6 @@
 
 <% content_for :title do %>
-      ステップ１-メモの選択
+      マイルールの作成
 <% end %>
 
 <%= render "if_then_rules/flow_navigation", step: @step %>

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -3,4 +3,5 @@
     <% content_for :title do %>
       If-Thenルール作成
     <% end %>
+    <%= render "if_then_rules/flow_navigation", step: @step %>
 <%= render "form", if_then_rule_form: @if_then_rule_form, url: if_then_rules_path, method: :post %>

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -1,7 +1,11 @@
 
-
-    <% content_for :title do %>
-      マイルールの作成
-    <% end %>
-    <%= render "if_then_rules/flow_navigation", step: @step %>
+<div class="relative">
+  <%= link_to '← メモ選択に戻る',
+    step1_if_then_rules_flow_path,
+    class: 'btn btn-ghost btn-sm' %>
+</div>
+<% content_for :title do %>
+  マイルールの作成
+<% end %>
+<%= render "if_then_rules/flow_navigation", step: @step %>
 <%= render "form", if_then_rule_form: @if_then_rule_form, url: if_then_rules_path, method: :post %>

--- a/app/views/if_then_rules/new.html.erb
+++ b/app/views/if_then_rules/new.html.erb
@@ -1,7 +1,7 @@
 
 
     <% content_for :title do %>
-      If-Thenルール作成
+      マイルールの作成
     <% end %>
     <%= render "if_then_rules/flow_navigation", step: @step %>
 <%= render "form", if_then_rule_form: @if_then_rule_form, url: if_then_rules_path, method: :post %>

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -1,6 +1,12 @@
     <% content_for :title do %>
       メモ作成
     <% end %>
+  <% if @from_rule_flow %>
+  <p class="text-sm ">
+    ルール作成フロー中（step1）
+  </p>
+ <%end%>
+
 
 <div class="card bg-memo shadow">
   <div class="card-body">

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -45,15 +45,29 @@
         <% end %>
       </div>
 
-      <!-- ボタン -->
-      <div class="flex justify-end gap-3">
-        <%= link_to "キャンセル",
-              memos_path,
-              class: "btn btn-ghost" %>
 
-        <%= f.submit "保存する",
-              class: "btn btn-primary" %>
-      </div>
+
+      <!-- ボタン -->
+        <% if @from_rule_flow %>
+          <!--ルール作成のフローの場合-->
+          <%= f.hidden_field :from, value: "rule_flow" %>
+          <div class="flex justify-end gap-3">
+            <%= f.submit "保存する",
+                  class: "btn btn-primary" %>
+          </div>
+        <% else %>
+            <!--ルール作成のフローではない通常のmemo作成-->
+          <div class="flex justify-end gap-3">
+            <%= link_to "キャンセル",
+                  memos_path,
+                  class: "btn btn-ghost" %>
+            <%= f.submit "保存する",
+                  class: "btn btn-primary" %>
+          </div>
+
+        <% end %>
+
+
     <% end %>
   </div>
 </div>

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -2,6 +2,11 @@
       メモ作成
     <% end %>
   <% if @from_rule_flow %>
+  <div class="relative">
+  <%= link_to '← step1メモ選択へ戻る',
+      step1_if_then_rules_flow_path,
+      class: 'btn btn-ghost btn-sm ' %>
+</div>
   <p class="text-sm ">
     ルール作成フロー中（step1）
   </p>

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -10,8 +10,7 @@
   <p class="text-sm ">
     ルール作成フロー中（step1）
   </p>
- <%end%>
-
+  <%end%>
 
 <div class="card bg-memo shadow">
   <div class="card-body">

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -1,6 +1,17 @@
     <% content_for :title do %>
       <%= @memo.title %>
     <% end %>
+<% if @from_rule_flow %>
+  <div class="relative">
+  <%= link_to '← step1メモ選択へ戻る',
+      step1_if_then_rules_flow_path,
+      class: 'btn btn-ghost btn-sm ' %>
+</div>
+  <p class="text-sm ">
+    ルール作成フロー中（step1）
+  </p>
+ <%end%>
+ 
 <div class=" px-4 py-8 bg-memo ">
 
 

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -11,7 +11,7 @@
     ルール作成フロー中（step1）
   </p>
  <%end%>
- 
+
 <div class=" px-4 py-8 bg-memo ">
 
 
@@ -22,21 +22,21 @@
 
   <!-- 操作ボタン群 -->
   <div class="flex flex-col gap-6 items-center ">
+    <% if !@from_rule_flow %>
+      <!-- 編集・削除 -->
+      <div class="flex gap-4">
+        <%= link_to "編集",
+                    edit_memo_path(@memo),
+                    class: "btn btn-outline btn-primary" %>
 
-    <!-- 編集・削除 -->
-    <div class="flex gap-4">
-      <%= link_to "編集",
-                  edit_memo_path(@memo),
-                  class: "btn btn-outline btn-primary" %>
-
-      <%= link_to "削除",
-                    memo_path(@memo),
-                    data: {
-                      turbo_method: :delete,
-                      turbo_confirm: "このメモを削除しますか？" },
-                    class: "btn btn-outline btn-error" %>
-    </div>
-
+        <%= link_to "削除",
+                      memo_path(@memo),
+                      data: {
+                        turbo_method: :delete,
+                        turbo_confirm: "このメモを削除しますか？" },
+                      class: "btn btn-outline btn-error" %>
+      </div>
+    <% end %>
     <!-- マイルール化ボタン -->
     <div>
       <%= link_to "このメモで新しいマイルールを作る",
@@ -45,7 +45,8 @@
     </div>
   </div>
 </div>
-<div>
-<%= link_to "一覧に戻る", memos_path, class: "btn btn-ghost btn-sm" %>
-</div>
-
+<% if !@from_rule_flow %>
+  <div>
+  <%= link_to "一覧に戻る", memos_path, class: "btn btn-ghost btn-sm" %>
+  </div>
+<% end %>

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -50,8 +50,6 @@ RSpec.describe "Memos", type: :request do
             }
           }
         }.to change(Memo, :count).by(1)
-
-
       end
     end
       context "異常系" do

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Memos", type: :request do
           }
         }.to change(Memo, :count).by(1)
 
-        expect(response).to redirect_to(memo_path(Memo.first))
+
       end
     end
       context "異常系" do


### PR DESCRIPTION
## 概要
- メモとルールの作成のステップ数のナビゲーションの追加
- 各ステップで戻るボタンの追加
- step1でもしくは"新しくメモを作成する"場合ルール作成のフローであることを明示、不要なボタンを隠す機能追加 

Close #199 

## 実装内容
### 予定していた作業
- [x] それぞれのコントローラーで現在のステップを識別させる
- [x] 新たなパーシャルでステップナビゲーションの作成
- [x] それまでのタイトルの名前変更



### 予定外だが実施した作業
- [x] 各ステップに戻るボタンを追加

- [x] step1で分岐する"新しくメモを作成する"場合ルール作成のフローであることを明示、不要なボタンを隠す機能追加 
<img width="585" height="519" alt="image" src="https://github.com/user-attachments/assets/71cf27fa-d445-4797-8f90-453c291f6489" />
- [x] リダイレクトの調整に伴いmemos_specでrequestスペックの"メモを作成する"テストの不要な部分を削除



## 動作確認
- [x] ステップのナビゲーションが表示されていてステップごとに機能する
<img width="602" height="588" alt="image" src="https://github.com/user-attachments/assets/f599cbcb-dc03-4391-828f-1f80573b2f68" />



## 備考
- step1で分岐する"新しくメモを作成する"ルートでは`@ @from_rule_flow`とif文を使用している。

  今後変えたりする場合これで検索するとよい
  またリクエストは`from: "rule_flow"`
  としてhidden_fieldやクエリパラメータ、リダイレクトにおいて指定している。

- 各ステップに戻るボタンを追加は変更で破損しないように相対ではなく直接的にパスを指定している。
