### PR TITLE
Feat/お試し利用機能作成(ルール作成機能特にwarnings機能のお試し)

### DIFF
--- a/app/controllers/trials_controller.rb
+++ b/app/controllers/trials_controller.rb
@@ -1,0 +1,20 @@
+class TrialsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create show]
+  before_action :redirect_if_logged_in, only: %i[ new create show]
+
+
+  def new
+  end
+
+  def create
+  end
+
+  def show
+  end
+
+  private
+
+  def redirect_if_logged_in
+    redirect_to dash_boards_path if logged_in?
+  end
+end

--- a/app/controllers/trials_controller.rb
+++ b/app/controllers/trials_controller.rb
@@ -1,6 +1,6 @@
 class TrialsController < ApplicationController
-  skip_before_action :require_login, only: %i[new create show]
-  before_action :redirect_if_logged_in, only: %i[ new create show]
+  skip_before_action :require_login, only: %i[new create show reload_guard]
+  before_action :redirect_if_logged_in, only: %i[ new create show reload_guard]
 
 
   def new
@@ -26,6 +26,10 @@ class TrialsController < ApplicationController
   end
 
   def show
+  end
+
+  def reload_guard
+      redirect_to new_trial_path, alert: "ページを再読み込みしました。もう一度入力してください。"
   end
 
   private

--- a/app/controllers/trials_controller.rb
+++ b/app/controllers/trials_controller.rb
@@ -5,20 +5,21 @@ class TrialsController < ApplicationController
 
   def new
     @trial_rule_form = TrialRuleForm.new()
-    @memo = Memo.find_by(id: @trial_rule_form.memo_id)
+    # @memo = Memo.find_by(id: @trial_rule_form.memo_id)
     @step = 2
   end
 
   def create
     @trial_rule_form = TrialRuleForm.new(trial_rule_params)
-    @memo = Memo.find_by(id: @trial_rule_form.memo_id)
+    # @memo = Memo.find_by(id: @trial_rule_form.memo_id)
     @step = 2
-    if @trial_rule_form.save(ignore_warnings: params[:commit_type] == "ignore_warnings")
-      redirect_to @trial_rule_form.status == "active" ? dash_boards_path : if_then_rules_path, notice: "If-Thenルールを作成しました"
+    if @trial_rule_form.savable?(ignore_warnings: params[:commit_type] == "ignore_warnings")
+      flash.now[:notice] = "If-Thenルールを作成しました(!お試しなので保存はしていません)"
+      render :show
     else
       flash.now[:alert] = "入力内容に問題があります。" if @trial_rule_form.errors.any?
 
-      flash.now[:warning] = "改善のヒント💡：改善できそうな点があります。内容を確認した上で、このまま保存することもできます。" if @trial_rule_form.warnings.any?
+      flash.now[:warning] = "改善のヒント💡：改善できそうな点があります。内容を確認した上で、このまま進めることもできます。" if @trial_rule_form.warnings.any?
 
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/trials_controller.rb
+++ b/app/controllers/trials_controller.rb
@@ -4,9 +4,24 @@ class TrialsController < ApplicationController
 
 
   def new
+    @trial_rule_form = TrialRuleForm.new()
+    @memo = Memo.find_by(id: @trial_rule_form.memo_id)
+    @step = 2
   end
 
   def create
+    @trial_rule_form = TrialRuleForm.new(trial_rule_params)
+    @memo = Memo.find_by(id: @trial_rule_form.memo_id)
+    @step = 2
+    if @trial_rule_form.save(ignore_warnings: params[:commit_type] == "ignore_warnings")
+      redirect_to @trial_rule_form.status == "active" ? dash_boards_path : if_then_rules_path, notice: "If-Thenルールを作成しました"
+    else
+      flash.now[:alert] = "入力内容に問題があります。" if @trial_rule_form.errors.any?
+
+      flash.now[:warning] = "改善のヒント💡：改善できそうな点があります。内容を確認した上で、このまま保存することもできます。" if @trial_rule_form.warnings.any?
+
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def show
@@ -16,5 +31,10 @@ class TrialsController < ApplicationController
 
   def redirect_if_logged_in
     redirect_to dash_boards_path if logged_in?
+  end
+
+  def trial_rule_params
+    params.require(:trial_rule_form)
+          .permit(:memo_id, :if_condition, :then_action, :status)
   end
 end

--- a/app/forms/trial_rule_form.rb
+++ b/app/forms/trial_rule_form.rb
@@ -11,7 +11,7 @@ class TrialRuleForm
   validates :then_action, presence: { message: "THEN（行動）を入力してください" }
 
   attr_reader :warnings
-  attr_reader :if_then_rule_of_model
+  # attr_reader :if_then_rule_of_model
 
   def initialize(attributes = {})
     super(attributes)
@@ -28,11 +28,8 @@ class TrialRuleForm
     valid? && (warnings.blank? || ignore_warnings)
   end
 
-  def save(ignore_warnings: false)
-    return false unless savable?(ignore_warnings: ignore_warnings)
-
-    return 
-
+  # def save(ignore_warnings: false)
+    # return false unless savable?(ignore_warnings: ignore_warnings)
     # trialでは保存はしない
     # if @if_then_rule_of_model
     #   # モデルが渡されている場合はeditからの文脈なのでupdateの処理
@@ -41,7 +38,7 @@ class TrialRuleForm
     #   # モデルが渡されてない場合はnewからの文脈なのでupdateの処理
     #   create_rule
     # end
-  end
+  # end
 
   # def apply_model_to_form
   #     # モデルが渡されている場合は属性の値入っていなければモデルのものになる(edit表示用にコントローラーで使う)

--- a/app/forms/trial_rule_form.rb
+++ b/app/forms/trial_rule_form.rb
@@ -29,15 +29,15 @@ class TrialRuleForm
   end
 
   # def save(ignore_warnings: false)
-    # return false unless savable?(ignore_warnings: ignore_warnings)
-    # trialでは保存はしない
-    # if @if_then_rule_of_model
-    #   # モデルが渡されている場合はeditからの文脈なのでupdateの処理
-    #   update_rule
-    # else
-    #   # モデルが渡されてない場合はnewからの文脈なのでupdateの処理
-    #   create_rule
-    # end
+  # return false unless savable?(ignore_warnings: ignore_warnings)
+  # trialでは保存はしない
+  # if @if_then_rule_of_model
+  #   # モデルが渡されている場合はeditからの文脈なのでupdateの処理
+  #   update_rule
+  # else
+  #   # モデルが渡されてない場合はnewからの文脈なのでupdateの処理
+  #   create_rule
+  # end
   # end
 
   # def apply_model_to_form

--- a/app/forms/trial_rule_form.rb
+++ b/app/forms/trial_rule_form.rb
@@ -1,0 +1,104 @@
+class TrialRuleForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :memo_id, :integer
+  attribute :if_condition, :string
+  attribute :then_action, :string
+  attribute :status, :string
+  # モデルにおいてstatusはintだがenum
+  validates :if_condition, presence: { message: "IF（きっかけ）を入力してください" }
+  validates :then_action, presence: { message: "THEN（行動）を入力してください" }
+
+  attr_reader :warnings
+  attr_reader :if_then_rule_of_model
+
+  def initialize(attributes = {})
+    super(attributes)
+    @warnings = []
+  end
+
+  def valid?(context = nil)
+    result = super
+    collect_warnings
+    result
+  end
+
+  def savable?(ignore_warnings: false)
+    valid? && (warnings.blank? || ignore_warnings)
+  end
+
+  def save(ignore_warnings: false)
+    return false unless savable?(ignore_warnings: ignore_warnings)
+
+    return 
+
+    # trialでは保存はしない
+    # if @if_then_rule_of_model
+    #   # モデルが渡されている場合はeditからの文脈なのでupdateの処理
+    #   update_rule
+    # else
+    #   # モデルが渡されてない場合はnewからの文脈なのでupdateの処理
+    #   create_rule
+    # end
+  end
+
+  # def apply_model_to_form
+  #     # モデルが渡されている場合は属性の値入っていなければモデルのものになる(edit表示用にコントローラーで使う)
+  #     return false unless @if_then_rule_of_model
+  #     self.memo_id      = if_then_rule_of_model.memo_id
+  #     self.if_condition = if_then_rule_of_model.if_condition
+  #     self.then_action  = if_then_rule_of_model.then_action
+  #     self.status  = if_then_rule_of_model.status
+  # end
+
+  # ↓ビュー(_form.html.erb)で使うwarningメッセージ集を取得するためのメソッド。
+  # @warningにはメッセージは入っていないがキーと今回検出されたキーワードが存在。
+  # そのキーと紐づけた素材、warning_conceptsにあるメッセージや検出されたワードを組み合わせる。
+  # それを配列としてwarningメッセージのパーツの塊の集まりとして返す
+  def warning_messages
+    @warnings.map do |w|
+      Warnings::WarningMessageBuilder.build(w)
+    end
+  end
+  private
+
+  def collect_warnings
+    # 編集時と新規作成で挙動が変化するものは編集前の元のルールである@if_then_rule_of_modelを渡す。
+    @warnings = []
+    @warnings += Warnings::IfAmbiguousTriggerExpressionChecker.check(if_condition)
+    @warnings += Warnings::IfUnobservableTriggerChecker.check(if_condition)
+    @warnings += Warnings::ThenNonVerifiableActionChecker.check(then_action)
+    @warnings += Warnings::ThenOversizedActionChecker.check(then_action)
+    @warnings += Warnings::ThenNegativeExpressionActionChecker.check(then_action)
+    # 以下,他のレコードが関わる構成系
+    # userが関わるcheckerはtrialでは機能しないので停止
+    # @warnings += Warnings::IfDuplicateContentChecker.check(
+    #   user: @current_user,
+    #   if_condition: if_condition,
+    #   exclude_id: @if_then_rule_of_model&.id
+    # )
+    # @warnings += Warnings::StatusTooManyActiveChecker.check(user: @current_user, status: status, current_rule: @if_then_rule_of_model)
+  end
+
+  # trialでは使用しない
+  # def create_rule
+  #     record = @current_user.if_then_rules.create(
+  #     memo_id: memo_id,
+  #     if_condition: if_condition,
+  #     then_action: then_action,
+  #     status: status
+  #   )
+  #    record.persisted?
+  # end
+
+  # trialでは使用しない
+  # def update_rule
+  #   @if_then_rule_of_model.update(
+  #     memo_id: memo_id,
+  #     if_condition: if_condition,
+  #     then_action: then_action,
+  #     status: status
+  #   )
+  # end
+end

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -17,7 +17,7 @@
     <div class="mt-4 flex flex-col gap-3">
       <%= link_to "新しくメモを作成する",
           new_memo_path,
-          class: "btn btn-secondry" %>
+          class: "btn btn-secondary" %>
     </div>
     
     <div class="card bg-base-100 shadow p-4 mt-16 ">

--- a/app/views/if_then_rules/cards/_rule_sentence.html.erb
+++ b/app/views/if_then_rules/cards/_rule_sentence.html.erb
@@ -1,11 +1,11 @@
-<p class="text-xs font-medium text-secondry text-left">
+<p class="text-xs font-medium text-secondary text-left">
   もし
 </p>
 <p class="text-md bg-blue-100 rounded px-2 py-1 text-primary">
   <%= rule.if_condition %>
 </p>
 
-<p class="text-xs font-medium text-secondry text-left">
+<p class="text-xs font-medium text-secondary text-left">
   その時は
 </p>
 <p class="text-lg font-semibold text-primary bg-green-100 rounded px-2 py-1">

--- a/app/views/pages/landing_page.html.erb
+++ b/app/views/pages/landing_page.html.erb
@@ -29,6 +29,7 @@
   <div class="mt-6 flex flex-col gap-3">
     <%= link_to "より詳しく", "/about" , class:"text-sm underline"%>
     <p class="text-sm  mb-1 animate-bounce">今日から小さなルール作りを始めましょう</p>
+    <%= link_to "試してみる", new_trial_path, class:"btn  btn-accent" %>
     <%= link_to "新規登録", new_user_path, class:"btn  btn-primary" %>
     <%= link_to "ログイン", login_path, class:"btn btn-outline" %>
 

--- a/app/views/trials/_trial_form.html.erb
+++ b/app/views/trials/_trial_form.html.erb
@@ -91,6 +91,7 @@
     <% end %>
     <!--フォームここまで-->
     <!--選択されているメモの表示-->
+    <!--
     <% if @memo %>
       <div class="bg-memo p-3 rounded text-sm">
         <p class="text-xs text-gray-400 mb-1">現在のメモ</p>
@@ -102,6 +103,7 @@
         元メモなし
       </p>
     <% end %>
+    -->
 </div>
 
 

--- a/app/views/trials/_trial_form.html.erb
+++ b/app/views/trials/_trial_form.html.erb
@@ -1,6 +1,6 @@
 <!--if_then_rule_formはフォームオブジェクト-->
 <div class ="space-y-6">
-  <%= form_with model: if_then_rule_form, url: url, method: method, class: "max-w-md mx-auto space-y-6" do |f| %>
+  <%= form_with model: if_then_rule_form, url: url, method: method, class: "max-w-md mx-auto space-y-6", data: { turbo: false } do |f| %>
     <%= f.hidden_field :memo_id %>
     <div class="p-4 rounded-lg bg-blue-50 border border-blue-100">
       <div class="form-control">

--- a/app/views/trials/_trial_form.html.erb
+++ b/app/views/trials/_trial_form.html.erb
@@ -1,0 +1,110 @@
+<!--if_then_rule_formはフォームオブジェクト-->
+<div class ="space-y-6">
+  <%= form_with model: if_then_rule_form, url: url, method: method, class: "max-w-md mx-auto space-y-6" do |f| %>
+    <%= f.hidden_field :memo_id %>
+    <div class="p-4 rounded-lg bg-blue-50 border border-blue-100">
+      <div class="form-control">
+        <%= f.label :if_condition, "もし", class: "label block text-left" %>
+        <%= f.text_field :if_condition,
+                        class: "input input-bordered",
+                        placeholder: "例：朝7時に起きたら" %>
+        <% if if_then_rule_form.errors[:if_condition].any? %>
+          <p class="text-sm text-red-600 mt-1">
+            <%= if_then_rule_form.errors[:if_condition].first %>
+          </p>
+        <% end %>
+
+      </div>
+      <!--warning表示-->
+      <%= render "if_then_rules/warning_messages", if_then_rule_form: if_then_rule_form, field: :if_condition %>
+      <details class="mt-2 group">
+        <summary class="text-sm text-gray-500 flex items-center gap-2 cursor-pointer list-none">
+          <span class="transition-transform group-open:rotate-90">▶</span>
+          💡 実行しやすいIFのチェックポイント
+          <p class="text-xs text-gray-400 font-light">セルフチェック用です。</p>
+        </summary>
+
+        <div class="mt-2 text-sm text-gray-600  p-3 rounded">
+          <%= render "if_then_rules/hint", target: :if %>
+        </div>
+      </details>
+
+
+    </div>
+    <div class="p-4 rounded-lg bg-green-50 border border-green-100">
+      <div class="form-control">
+        <%= f.label :then_action, "その時は", class: "label block text-left" %>
+        <%= f.text_field :then_action,
+                        class: "input input-bordered",
+                        placeholder: "例：コップ一杯の水を飲む" %>
+        <% if if_then_rule_form.errors[:then_action].any? %>
+          <p class="text-sm text-red-600 mt-1">
+            <%= if_then_rule_form.errors[:then_action].first %>
+          </p>
+        <% end %>
+
+      </div>
+      <!--warning表示-->
+      <%= render "if_then_rules/warning_messages", if_then_rule_form: if_then_rule_form, field: :then_action %>
+      <details class="mt-2 group">
+        <summary class="text-sm text-gray-500 flex items-center gap-2 cursor-pointer list-none">
+          <span class="transition-transform group-open:rotate-90">▶</span>
+          💡 実行しやすいTHENのチェックポイント
+          <p class="text-xs text-gray-400 font-light">セルフチェック用です。</p>
+        </summary>
+        <div class="mt-2 text-sm text-gray-600  p-3 rounded">
+          <%= render "if_then_rules/hint", target: :then %>
+        </div>
+      </details>
+    </div>
+    <%= f.label :status, "状態", class: "label" %>
+    <%= f.select :status, [ ["実行中", "active"],["未実行", "draft"],["定着済み", "habituated"]] %>
+
+
+    <!--warning確認を無視するトグル-->
+    <%= hidden_field_tag :commit_type, "" %>
+
+    <label class="flex items-center gap-2">
+      <%= check_box_tag :commit_type,
+            "ignore_warnings",
+            controller.action_name == "edit" ? true : false,
+            class: "toggle toggle-primary" %>
+      <span class="text-sm">ヒントの自動チェックをしない</span>
+    </label>
+
+    <!--保存ボタンなど-->
+    <div class="pt-4 space-y-3">
+      <% if if_then_rule_form.warnings.present? %>
+
+
+        <%= f.button "もう一度確認して保存する",
+
+                    class: "btn btn-secondary w-full" %>
+
+      <% else %>
+
+        <%= f.button "保存する",
+                    class: "btn btn-primary w-full" %>
+      <% end %>
+    </div>
+
+    <% end %>
+    <!--フォームここまで-->
+    <!--選択されているメモの表示-->
+    <% if @memo %>
+      <div class="bg-memo p-3 rounded text-sm">
+        <p class="text-xs text-gray-400 mb-1">現在のメモ</p>
+        <%= @memo.title %>
+        <%= @memo.body %>
+      </div>
+    <% else %>
+      <p class="text-xs text-gray-400">
+        元メモなし
+      </p>
+    <% end %>
+</div>
+
+
+
+
+

--- a/app/views/trials/create.html.erb
+++ b/app/views/trials/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Trials#create</h1>
+<p>Find me in app/views/trials/create.html.erb</p>

--- a/app/views/trials/create.html.erb
+++ b/app/views/trials/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Trials#create</h1>
-<p>Find me in app/views/trials/create.html.erb</p>

--- a/app/views/trials/new.html.erb
+++ b/app/views/trials/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Trials#new</h1>
+<p>Find me in app/views/trials/new.html.erb</p>

--- a/app/views/trials/new.html.erb
+++ b/app/views/trials/new.html.erb
@@ -1,2 +1,10 @@
-<h1>Trials#new</h1>
-<p>Find me in app/views/trials/new.html.erb</p>
+<div class="relative">
+  <%= link_to '← 説明ページへ戻る',
+    root_path,
+    class: 'btn btn-ghost btn-sm' %>
+</div>
+<% content_for :title do %>
+  マイルールの作成(お試し)
+<% end %>
+
+<%= render "trial_form", if_then_rule_form: @trial_rule_form, url: trials_path, method: :post %>

--- a/app/views/trials/new.html.erb
+++ b/app/views/trials/new.html.erb
@@ -6,5 +6,8 @@
 <% content_for :title do %>
   マイルールの作成(お試し)
 <% end %>
-
+<div class="card bg-base-100 text-gray-800 text-sm space-y-2 p-2">
+  <p>ifでは"常に"や"いつも"などのトリガーとして機能しにくい条件をいれると警告として止める機能があります。</p>
+  <p>thenでは"完成"や"終わらせる"などの実行するには大きすぎる行動をいれると警告として止める機能があります。</p>
+</div>
 <%= render "trial_form", if_then_rule_form: @trial_rule_form, url: trials_path, method: :post %>

--- a/app/views/trials/show.html.erb
+++ b/app/views/trials/show.html.erb
@@ -1,2 +1,4 @@
 <h1>Trials#show</h1>
 <p>Find me in app/views/trials/show.html.erb</p>
+<%= @trial_rule_form %>
+<%= @trial_rule_form %>

--- a/app/views/trials/show.html.erb
+++ b/app/views/trials/show.html.erb
@@ -1,4 +1,6 @@
-<h1>Trials#show</h1>
-<p>Find me in app/views/trials/show.html.erb</p>
-<%= @trial_rule_form %>
-<%= @trial_rule_form %>
+<% content_for :title do %>
+  マイルール作成(お試し)
+<% end %>
+<div class="  bg-base-100 card shadow-md rounded-lg  space-y-2 p-4">
+<%= render "if_then_rules/cards/rule_sentence", rule: @trial_rule_form %>
+</div>

--- a/app/views/trials/show.html.erb
+++ b/app/views/trials/show.html.erb
@@ -4,3 +4,11 @@
 <div class="  bg-base-100 card shadow-md rounded-lg  space-y-2 p-4">
 <%= render "if_then_rules/cards/rule_sentence", rule: @trial_rule_form %>
 </div>
+<div class="mt-6 flex flex-col gap-3">
+  <p class="text-center mb-3">
+    今回の内容はお試しです。<br>
+    新規登録すると、ルールを保存して使えるようになります。
+  </p>
+  <%= link_to "新規登録", new_user_path, class:"btn  btn-primary" %>
+  <%= link_to "もう一度試してみる", new_trial_path, class:"btn  btn-ghost" %>
+</div>

--- a/app/views/trials/show.html.erb
+++ b/app/views/trials/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Trials#show</h1>
+<p>Find me in app/views/trials/show.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
   get  "/term",  to: "pages#term"
   get  "/privacy",  to: "pages#privacy"
   # トライアル機能
-  resources :trials, only: %i[ new create  ]
+  resources :trials, only: %i[ new create  ] 
+  get  "/trials", to: "trials#reload_guard"
+
+  # ダッシュボード
   resources :dash_boards, only: [ :index ]
   # 新規登録機能->users
   resources :users, only: [ :new, :create ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get  "/about",  to: "pages#about"
   get  "/term",  to: "pages#term"
   get  "/privacy",  to: "pages#privacy"
+  # トライアル機能
+  resources :trials, only: %i[ new create show ]
   resources :dash_boards, only: [ :index ]
   # 新規登録機能->users
   resources :users, only: [ :new, :create ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get  "/term",  to: "pages#term"
   get  "/privacy",  to: "pages#privacy"
   # トライアル機能
-  resources :trials, only: %i[ new create show ]
+  resources :trials, only: %i[ new create  ]
   resources :dash_boards, only: [ :index ]
   # 新規登録機能->users
   resources :users, only: [ :new, :create ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
   get  "/term",  to: "pages#term"
   get  "/privacy",  to: "pages#privacy"
   # トライアル機能
-  resources :trials, only: %i[ new create  ] 
-  get  "/trials", to: "trials#reload_guard"
+  resources :trials, only: %i[ new create  ]
+  get "/trials", to: "trials#reload_guard"
 
   # ダッシュボード
   resources :dash_boards, only: [ :index ]

--- a/spec/forms/trial_rule_form_spec.rb
+++ b/spec/forms/trial_rule_form_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe TrialRuleForm do
+  describe "#savable?" do
+    context "正常系" do
+      context "必須項目がwarnings警告不要な内容で揃っている場合" do
+        it "trueを返す" do
+          form = described_class.new(
+            if_condition: "朝起きたら",
+            then_action: "水を飲む"
+          )
+
+          expect(form.savable?).to be true
+        end
+      end
+
+
+      context "警告(warnings)があり ignore_warnings=false の場合" do
+        it "falseを返す" do
+          form = described_class.new(
+            if_condition: "いつも",
+            then_action: "水を飲む"
+          )
+
+          expect(form.savable?).to be false
+        end
+      end
+      context "警告(warnings)はあるが ignore_warnings=true の場合" do
+        it "trueを返す" do
+            form = described_class.new(
+            if_condition: "いつも",
+          then_action: "水を飲む"
+          )
+          expect(form.savable?(ignore_warnings: true)).to be true
+        end
+      end
+    end
+
+    context "異常系" do
+      context "必須項目が欠けている場合(エラーがある場合)" do
+        it "if_condition が空だと false を返す" do
+          form = described_class.new(
+            if_condition: "",
+            then_action: "水を飲む"
+          )
+
+          expect(form.savable?).to be false
+        end
+
+        it "then_action が空だと false を返す" do
+          form = described_class.new(
+            if_condition: "朝起きたら",
+            then_action: ""
+          )
+
+          expect(form.savable?).to be false
+        end
+        it "ignore_warnings=true でも false を返す" do
+          form = described_class.new(
+            if_condition: "",
+            then_action: ""
+          )
+
+          expect(form.savable?(ignore_warnings: true)).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION

## 概要
お試し利用機能作成(ルール作成機能特にwarnings機能のお試し)

Close #153 

## 実装内容
### 予定していた作業

- [x] 新たにtrials_controllerという形でtrial機能の入り口(new create show)を作る
- [x] 現在のif_then_rules_formのフォームオブジェクトを参考にして新しいtrialのためのtrial_rule_formを作る
- [x] createの後にリダイレクトをしないで renderにする
- [x] showの画面に新規ユーザー登録画面へ移行するパスをつける 


### 予定外だが実施した作業
- [x] createの後にリダイレクトせずrender :showを機能させるためお試しのturbo_streamをfalseへ
- [x]  createの後にリダイレクトせずrender :showでのリロードでエラーが出ないように"/trials"GETに対応する、":new"にリダイレクトさせる":reload_guard"の追加
- [x] ログイン前でも使用できるように今回のお試し系のルートに対してskip_before_actionなどをランディングページと同様に設定

## 動作確認
- [x] ランディングページからお試しに遷移できる
<img width="619" height="664" alt="image" src="https://github.com/user-attachments/assets/bc206fcf-07cc-48be-aac5-6e74d516476c" />

- [x]  通常のルール作成と同じようにwarnings機能などが動く(ただし既存ルールの個数に関するwarningは停止している)
<img width="617" height="826" alt="image" src="https://github.com/user-attachments/assets/b0cda5f0-cbd6-4afc-ab62-3201f0cc2c2e" />

- [x] お試しでの作成後の画面で本登録へのリンクがある
<img width="615" height="500" alt="image" src="https://github.com/user-attachments/assets/58d848a8-013a-4d87-ac2e-c015111a663a" />

## 備考
 - 本登録で引き継げるような機能は今回は未実装、今後のイシューでメモのデータの仕様が変わる可能性もあるため