### PR TITLE
Feat/ifthenルール作成時の下書きで保存する機能の実装

### DIFF
--- a/app/forms/if_then_rule_form.rb
+++ b/app/forms/if_then_rule_form.rb
@@ -7,8 +7,8 @@ class IfThenRuleForm
   attribute :then_action, :string
   attribute :status, :string
   # モデルにおいてstatusはintだがenum
-  validates :if_condition, presence: { message: "IF（きっかけ）を入力してください" }
-  validates :then_action, presence: { message: "THEN（行動）を入力してください" }
+  validates :if_condition, presence: { message: "IF（きっかけ）を入力してください" }, unless: -> { status == "draft" }
+  validates :then_action, presence: { message: "THEN（行動）を入力してください" }, unless: -> { status == "draft" }
 
   attr_reader :warnings
   attr_reader :user
@@ -99,4 +99,6 @@ class IfThenRuleForm
       status: status
     )
   end
+
+  
 end

--- a/app/forms/if_then_rule_form.rb
+++ b/app/forms/if_then_rule_form.rb
@@ -99,6 +99,4 @@ class IfThenRuleForm
       status: status
     )
   end
-
-  
 end

--- a/app/forms/trial_rule_form.rb
+++ b/app/forms/trial_rule_form.rb
@@ -7,8 +7,8 @@ class TrialRuleForm
   attribute :then_action, :string
   attribute :status, :string
   # モデルにおいてstatusはintだがenum
-  validates :if_condition, presence: { message: "IF（きっかけ）を入力してください" }
-  validates :then_action, presence: { message: "THEN（行動）を入力してください" }
+  validates :if_condition, presence: { message: "IF（きっかけ）を入力してください" }, unless: -> { status == "draft" }
+  validates :then_action, presence: { message: "THEN（行動）を入力してください" }, unless: -> { status == "draft" }
 
   attr_reader :warnings
   # attr_reader :if_then_rule_of_model

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -3,9 +3,9 @@ class IfThenRule < ApplicationRecord
   belongs_to :memo, optional: true
   has_many :reflections, dependent: :destroy
 
-  enum status: { draft: 0, active: 1, habituated: 2 }
-  validates :if_condition, presence: true, if: :active?
-  validates :then_action, presence: true, if: :active?
+  enum status: { inactive: 0, active: 1, habituated: 2, draft: 3 }
+  validates :if_condition, presence: true, unless: :draft?
+  validates :then_action, presence: true, unless: :draft?
   validates :status, presence: true
 
   def reflected_today?
@@ -18,7 +18,8 @@ class IfThenRule < ApplicationRecord
 
   def human_status
     case status
-    when "draft" then "未実行"
+    when "draft" then "下書き"
+    when "inactive" then "停止中"
     when "active" then "実行中"
     when "habituated" then "定着済み"
     end

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -58,7 +58,7 @@
       </details>
     </div>
     <%= f.label :status, "状態", class: "label" %>
-    <%= f.select :status, [ ["実行中", "active"],["未実行", "draft"],["定着済み", "habituated"]], {selected: change_default_status(@active_if_then_rules,set_status:if_then_rule_form.status)} %>
+    <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"],["停止中", "inactive"],["定着済み", "habituated"]], {selected: change_default_status(@active_if_then_rules,set_status:if_then_rule_form.status)} %>
 
     <!--statusのwarning_message-->
     <%= render "if_then_rules/warning_messages", if_then_rule_form: if_then_rule_form, field: :status %>

--- a/app/views/trials/_trial_form.html.erb
+++ b/app/views/trials/_trial_form.html.erb
@@ -58,7 +58,7 @@
       </details>
     </div>
     <%= f.label :status, "状態", class: "label" %>
-    <%= f.select :status, [ ["実行中", "active"],["未実行", "draft"],["定着済み", "habituated"]] %>
+    <%= f.select :status, [ ["実行中", "active"],["下書き", "draft"],["停止中", "inactive"],["未実行", "draft"],["定着済み", "habituated"]] %>
 
 
     <!--warning確認を無視するトグル-->

--- a/spec/forms/if_then_rule_form_spec.rb
+++ b/spec/forms/if_then_rule_form_spec.rb
@@ -203,7 +203,7 @@ end
               memo_id: memo.id,
               if_condition: "",
               then_action: "水を飲む",
-              status: "draft"
+              status: "active"
             },
             user: user,
             if_then_rule_of_model: if_then_rule

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -93,30 +93,6 @@ RSpec.describe IfThenRule, type: :model do
     end
 
 
-    describe "#human_status" do
-        context "status が draft のとき" do
-    before { rule.update!(status: :draft) }
 
-    it "未実行 を返す" do
-      expect(rule.human_status).to eq "未実行"
-    end
-  end
-
-  context "status が active のとき" do
-    before { rule.update!(status: :active) }
-
-    it "実行中 を返す" do
-      expect(rule.human_status).to eq "実行中"
-    end
-  end
-
-  context "status が habituated のとき" do
-    before { rule.update!(status: :habituated) }
-
-    it "定着済み を返す" do
-      expect(rule.human_status).to eq "定着済み"
-    end
-  end
-    end
   end
 end

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -91,8 +91,5 @@ RSpec.describe IfThenRule, type: :model do
         end
       end
     end
-
-
-
   end
 end


### PR DESCRIPTION

## 概要
ifthenルール作成時の下書きで保存する機能の実装

Close #79 

## 実装内容
### 予定していた作業
- [x] 新たなstatus,enumを作成,draftとinactiveとして分離
- [x] フォームのセレクトボックスにも新項目を追加 
- [x] モデルのnilバリデーションの削除
- [x] フォームオブジェクトの方にdraft以外の時だけnilバリデーションをする形に変更




### 予定外だが実施した作業
- [x] 不要なspecの削除（実装をそのままコピーに等しい不要なテスト）
- [x] tralについても対応する箇所を一応同様に下書きで作れるようにはしている

## 動作確認
- [x] ステータスを下書きで保存する場合であればifやthenが空欄でもルールが保存,編集できること 

<img width="555" height="377" alt="image" src="https://github.com/user-attachments/assets/d8a9d771-621d-4e1b-8f97-f9016b0a9032" />

## 備考
if_then_rule_formのスペックがかなりゴチャゴチャしていて
安心感がないので作り直した方が良いかもしれない。
一応はメインの場所なのできちんとつくる。
この際、`spec/forms/if_then_rule_forms/if_then_rule_form_validate.rbやif_then_rule_form_warnings.rb`
というような形で複数ファイルに分けてもいいかもしれない。