### PR TITLE
Feat/memoの作成のタイトルの項目を任意にする

### DIFF
--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -4,9 +4,15 @@ class Memo < ApplicationRecord
   validates :title, length: { maximum: 100 }
   validates :body, length: { maximum: 10_000 }
 
+
+  def display_title
+    title.present? ? title.truncate(20) : "（無題）"
+  end
+
   def display_for_select
     title_text = title.present? ? title.truncate(20) : "（無題）"
     body_text = body.presence&.truncate(10)
     "#{title_text} - #{body_text}"
   end
+
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -1,7 +1,7 @@
 class Memo < ApplicationRecord
   belongs_to :user
   has_many :if_then_rules, dependent: :nullify
-  validates :title, presence: :true, length: { maximum: 100 }
+  validates :title, length: { maximum: 100 }
   validates :body, length: { maximum: 10_000 }
 
   def display_for_select

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -14,5 +14,4 @@ class Memo < ApplicationRecord
     body_text = body.presence&.truncate(10)
     "#{title_text} - #{body_text}"
   end
-
 end

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -13,7 +13,7 @@
         <div class="bg-memo card shadow-md rounded-lg p-4">
           <div>
             <h2 class="card-title">
-              <%= memo.title %>
+              <%= memo.display_title %>
             </h2>
 
             <div class="card-body">

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -1,5 +1,5 @@
     <% content_for :title do %>
-      <%= @memo.title %>
+      <%= @memo.title.presence ||  "(無題)" %>
     <% end %>
 <% if @from_rule_flow %>
   <div class="relative">

--- a/db/migrate/20260210075234_change_title_null_on_memos.rb
+++ b/db/migrate/20260210075234_change_title_null_on_memos.rb
@@ -1,0 +1,5 @@
+class ChangeTitleNullOnMemos < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :memos, :title, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_05_100641) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_10_075234) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_05_100641) do
   end
 
   create_table "memos", force: :cascade do |t|
-    t.string "title", null: false
+    t.string "title"
     t.text "body"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -8,11 +8,6 @@ RSpec.describe Memo, type: :model do
       expect(memo).to be_valid
     end
 
-    it "title が空だと無効" do
-      memo = build(:memo, title: nil, user: user)
-      expect(memo).not_to be_valid
-      expect(memo.errors[:title]).to include("can't be blank")
-    end
 
     it "title が100文字を超えると無効" do
       memo = build(:memo, title: "a" * 101, user: user)

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -52,23 +52,7 @@ RSpec.describe "Memos", type: :request do
         }.to change(Memo, :count).by(1)
       end
     end
-      context "異常系" do
-        context "ログインしている場合" do
-          it "作成に失敗しnewを再表示する" do
-            login_as(user)
 
-            post memos_path, params: {
-              memo: {
-                title: "",
-                body: "本文"
-              }
-            }
-
-            expect(response).to have_http_status(:unprocessable_content)
-            expect(response.body).to include("メモの作成")
-          end
-        end
-      end
   end
   describe "PATCH /memos/:id(edit->updateのテスト)" do
     it "メモを更新できる" do

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe "Memos", type: :request do
         }.to change(Memo, :count).by(1)
       end
     end
-
   end
   describe "PATCH /memos/:id(edit->updateのテスト)" do
     it "メモを更新できる" do


### PR DESCRIPTION

## 概要
memoの作成のタイトルの項目を任意にする


Close #165 

## 実装内容
### 予定していた作業
- [x] model/memo.rbのバリデーションの変更
- [x] マイグレーションでも同様に タイトルの条件の変更

  - [x] title項目がnilや空でもエラーにならないように調整(ビュー)



### 予定外だが実施した作業
- [x] memoモデルの方でnilのタイトルように"無題"と表示するメソッド追加し一覧表示で使用(同時にtruncate(20)にすることで一覧表示を見やすくする効果もあり)
- [x] memoの詳細表示でnilの場合"無題"と表示数機能追加(こちらは省略しない方が良いのでそのままの表示)

## 動作確認
- [x] title無しmemo作成可能

<img width="355" height="254" alt="image" src="https://github.com/user-attachments/assets/8e911ee1-df0d-4ed3-9562-85b90c39bc09" />

