### PR TITLE
Feat/一定以上触れられてないメモをタグのように検索、ソートする機能

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -5,6 +5,11 @@ class MemosController < ApplicationController
     @searched_memos = @q.result(distinct: true)
   end
 
+  def stale
+    @memos = current_user.memos
+    @searched_memos = @memos.stale
+  end
+
   def new
     @memo = current_user.memos.build
     @from_rule_flow = params[:from] == "rule_flow"

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -7,7 +7,7 @@ class MemosController < ApplicationController
 
   def stale
     @memos = current_user.memos
-    @searched_memos = @memos.stale
+    @searched_memos = @memos.stale(days = 7)
   end
 
   def new

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -3,7 +3,7 @@ class Memo < ApplicationRecord
   has_many :if_then_rules, dependent: :nullify
   validates :title, length: { maximum: 100 }
   validates :body, length: { maximum: 10_000 }
-
+# 未整理のメモは7日以上前かつルールとの紐付けがないものとして今回は指定している,調整にはdaysで変える。
   scope :stale, ->(days = 7) {
   left_outer_joins(:if_then_rules)
     .where(if_then_rules: { id: nil })

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -3,7 +3,7 @@ class Memo < ApplicationRecord
   has_many :if_then_rules, dependent: :nullify
   validates :title, length: { maximum: 100 }
   validates :body, length: { maximum: 10_000 }
-# 未整理のメモは7日以上前かつルールとの紐付けがないものとして今回は指定している,調整にはdaysで変える。
+  # 未整理のメモは7日以上前かつルールとの紐付けがないものとして今回は指定している,調整にはdaysで変える。
   scope :stale, ->(days = 7) {
   left_outer_joins(:if_then_rules)
     .where(if_then_rules: { id: nil })

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -4,6 +4,12 @@ class Memo < ApplicationRecord
   validates :title, length: { maximum: 100 }
   validates :body, length: { maximum: 10_000 }
 
+  scope :stale, ->(days = 7) {
+  left_outer_joins(:if_then_rules)
+    .where(if_then_rules: { id: nil })
+    .where("memos.updated_at <= ?", days.days.ago)
+}
+
   def self.ransackable_attributes(auth_object = nil)
     [ "title", "body" ]
   end

--- a/app/views/memos/stale.html.erb
+++ b/app/views/memos/stale.html.erb
@@ -1,38 +1,10 @@
     <% content_for :title do %>
-      メモ一覧
+      未整理メモ一覧
     <% end %>
-    <% if @memos.any? %>
-      <div>
-        <%= search_form_for @q do |f| %>
-          <div class="flex gap-2 sm:flex-row flex-col">
+    <div>
+        <%= link_to "通常のメモ一覧へ", memos_path, class: "btn btn-ghost btn-sm" %>
+    </div>
 
-            <label class="input input-primary flex items-center gap-2 w-full">
-              <!-- 🔍 アイコン -->
-              <svg xmlns="http://www.w3.org/2000/svg"
-                  class="h-4 w-4 opacity-70"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor">
-                <path stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="m21 21-4.35-4.35m1.85-5.65a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" />
-              </svg>
-
-              <%= f.search_field :title_or_body_cont,
-                    class: "grow",
-                    placeholder: "メモを検索..." %>
-            </label>
-
-            <%= f.submit "検索",
-                  class: "btn btn-primary" %>
-
-          </div>
-        <% end %>
-        <%= link_to "検索をクリア", memos_path, class: "btn btn-ghost btn-sm" %>
-        <%= link_to "未整理メモ", stale_memos_path, class: "btn btn-ghost btn-sm" %>
-      </div>
-    <% end %>
 
   <% if @searched_memos.any? %>
 
@@ -70,7 +42,7 @@
                     data: {
                       turbo_method: :delete,
                       turbo_confirm: "このメモを削除しますか？" },
-                    class: "btn btn-sm btn-ghost btn-error" %>
+                    class: "btn btn-lg btn-ghost btn-error " %>
             </div>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   post "/login",  to: "user_sessions#create"
   delete "/logout", to: "user_sessions#destroy"
   # メモの機能->memos
-  resources :memos do 
+  resources :memos do
     collection do
       get :stale
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,11 @@ Rails.application.routes.draw do
   post "/login",  to: "user_sessions#create"
   delete "/logout", to: "user_sessions#destroy"
   # メモの機能->memos
-  resources :memos
+  resources :memos do 
+    collection do
+      get :stale
+    end
+  end
   # ifthenの表示機能->if_then_rules
   resources :if_then_rules, only: %i[ index show new create edit update destroy] do
     resources :reflections, only: %i[create destroy]

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Memo, type: :model do
-  let(:user) { User.create }
+  let(:user) { create(:user) }
   describe "バリデーション" do
     it "title があれば有効" do
       memo = build(:memo, title: "テストメモ", user: user)
@@ -31,6 +31,39 @@ RSpec.describe Memo, type: :model do
       memo = build(:memo, title: "タイトル", body: nil)
 
       expect(memo.display_for_select).to end_with(" - ")
+    end
+  end
+
+  describe ".stale" do
+    context "取得される条件" do
+      it "7日以上前かつルールがない場合に取得されること" do
+        memo = create(:memo,
+          user: user,
+          updated_at: 8.days.ago)
+
+        expect(Memo.stale).to include(memo)
+      end
+    end
+    context "取得されない条件" do
+      it "updated_atが6日前の場合取得されないこと" do
+        memo = create(:memo,
+        user: user,
+        updated_at: 6.days.ago
+      )
+
+      expect(Memo.stale).not_to include(memo)
+      end
+
+      it 'ルールが存在する場合取得されないこと' do
+        memo = create(:memo,
+          user: user,
+          updated_at: 10.days.ago
+        )
+
+        create(:if_then_rule, memo: memo, user: user)
+
+        expect(Memo.stale).not_to include(memo)
+      end
     end
   end
 end

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Memo, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
   let(:user) { create(:user) }
   describe "バリデーション" do
     it "title があれば有効" do
@@ -35,34 +36,61 @@ RSpec.describe Memo, type: :model do
   end
 
   describe ".stale" do
-    context "取得される条件" do
-      it "7日以上前かつルールがない場合に取得されること" do
-        memo = create(:memo,
-          user: user,
-          updated_at: 8.days.ago)
-
-        expect(Memo.stale).to include(memo)
+    subject { Memo.stale(days) }
+  
+    let(:days) { 7 }
+    let(:user) { create(:user) }
+  
+    around do |example|
+      freeze_time { example.run }
+    end
+  
+    context "取得される場合(7日よりupdated_atが前かつルールを持たないもの)" do
+      context "updated_atが8日前でルールがない場合" do
+        let!(:memo) { create(:memo, user: user, updated_at: 8.days.ago) }
+        it "取得されること" do
+          expect(subject).to include(memo)
+        end
+      end
+    
+      context "updated_atがちょうど7日前でルールがない場合" do
+        let!(:memo) { create(:memo, user: user, updated_at: 7.days.ago) }
+    
+        it "取得されること" do
+          expect(subject).to include(memo)
+        end
       end
     end
-    context "取得されない条件" do
-      it "updated_atが6日前の場合取得されないこと" do
-        memo = create(:memo,
-        user: user,
-        updated_at: 6.days.ago
-      )
-
-      expect(Memo.stale).not_to include(memo)
+    context "取得されない場合(6日以内あるいはルールを持つ場合)" do
+      context "updated_atが6日前の場合" do
+        let!(:memo) { create(:memo, user: user, updated_at: 6.days.ago) }
+    
+        it "取得されないこと" do
+          expect(subject).not_to include(memo)
+        end
       end
+    
+      context "ルールが存在する場合" do
+        let!(:memo) { create(:memo, user: user, updated_at: 10.days.ago) }
+    
+        before do
+          create(:if_then_rule, memo: memo, user: user)
+        end
+    
+        it "取得されないこと" do
+          expect(subject).not_to include(memo)
+        end
+      end
+    end
 
-      it 'ルールが存在する場合取得されないこと' do
-        memo = create(:memo,
-          user: user,
-          updated_at: 10.days.ago
-        )
-
-        create(:if_then_rule, memo: memo, user: user)
-
-        expect(Memo.stale).not_to include(memo)
+    context "日数を指定した場合" do
+      context "30日指定の場合" do
+        let(:days) { 30 }
+        let!(:memo) { create(:memo, user: user, updated_at: 30.days.ago) }
+    
+        it "取得されること" do
+          expect(subject).to include(memo)
+        end
       end
     end
   end

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe Memo, type: :model do
 
   describe ".stale" do
     subject { Memo.stale(days) }
-  
+
     let(:days) { 7 }
     let(:user) { create(:user) }
-  
+
     around do |example|
       freeze_time { example.run }
     end
-  
+
     context "取得される場合(7日よりupdated_atが前かつルールを持たないもの)" do
       context "updated_atが8日前でルールがない場合" do
         let!(:memo) { create(:memo, user: user, updated_at: 8.days.ago) }
@@ -52,10 +52,10 @@ RSpec.describe Memo, type: :model do
           expect(subject).to include(memo)
         end
       end
-    
+
       context "updated_atがちょうど7日前でルールがない場合" do
         let!(:memo) { create(:memo, user: user, updated_at: 7.days.ago) }
-    
+
         it "取得されること" do
           expect(subject).to include(memo)
         end
@@ -64,19 +64,19 @@ RSpec.describe Memo, type: :model do
     context "取得されない場合(6日以内あるいはルールを持つ場合)" do
       context "updated_atが6日前の場合" do
         let!(:memo) { create(:memo, user: user, updated_at: 6.days.ago) }
-    
+
         it "取得されないこと" do
           expect(subject).not_to include(memo)
         end
       end
-    
+
       context "ルールが存在する場合" do
         let!(:memo) { create(:memo, user: user, updated_at: 10.days.ago) }
-    
+
         before do
           create(:if_then_rule, memo: memo, user: user)
         end
-    
+
         it "取得されないこと" do
           expect(subject).not_to include(memo)
         end
@@ -87,7 +87,7 @@ RSpec.describe Memo, type: :model do
       context "30日指定の場合" do
         let(:days) { 30 }
         let!(:memo) { create(:memo, user: user, updated_at: 30.days.ago) }
-    
+
         it "取得されること" do
           expect(subject).to include(memo)
         end

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -2,6 +2,16 @@ RSpec.describe "Memos", type: :request do
   include LoginHelper
   let(:user) { create(:user, password: "password") }
   let(:memo) { create(:memo, user: user) }
+  let(:other_user) { create(:user) }
+  let!(:my_memo) do
+    create(:memo, user: user, title: "my memo")
+  end
+
+  let!(:other_user_memo) do
+    create(:memo, user: other_user, title: "other memo")
+  end
+
+
 
   describe "GET /memos(メモ一覧表示)" do
     context "未ログインの場合" do
@@ -12,12 +22,18 @@ RSpec.describe "Memos", type: :request do
     end
 
     context "ログインしている場合" do
-      it "一覧が表示される" do
+      before do
         login_as(user)
         get memos_path
-
+      end
+      it "一覧が表示される" do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("メモ一覧")
+      end
+
+      it "他のユーザーのものが含まれない" do
+        expect(response.body).to include("my memo")
+        expect(response.body).not_to include("other memo")
       end
     end
   end
@@ -86,5 +102,40 @@ RSpec.describe "Memos", type: :request do
       expect(IfThenRule.exists?(rule.id)).to be true
       expect(rule.reload.memo_id).to be_nil
     end
+  end
+
+  describe "GET /memos/stale(#staleのテスト)" do
+    context "未ログインの場合" do
+      it "login_pathにリダイレクトされる" do
+        get stale_memos_path
+
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context "ログインしている場合" do
+      before do
+        login_as(user)
+        get stale_memos_path
+      end
+      let!(:my_memo) do
+        create(:memo, user: user, updated_at: 8.days.ago, title: "my memo")
+      end
+    
+      let!(:other_user_memo) do
+        create(:memo, user: other_user, updated_at: 8.days.ago, title: "other memo")
+      end
+      it "未整理のメモ一覧が表示される" do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("未整理メモ一覧")
+      end
+      it "他のユーザーのものが含まれない" do
+        expect(response.body).to include("my memo")
+        expect(response.body).not_to include("other memo")
+      end
+    end
+
+
+
   end
 end

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Memos", type: :request do
         expect(response).to redirect_to(login_path)
       end
     end
-    context "正常系" do
+    context "ログインしている場合" do
       it "メモを作成できる" do
         login_as(user)
 
@@ -70,37 +70,54 @@ RSpec.describe "Memos", type: :request do
     end
   end
   describe "PATCH /memos/:id(edit->updateのテスト)" do
-    it "メモを更新できる" do
-      login_as(user)
+    context "未ログインの場合" do
+      it "login_pathにリダイレクトされる" do
+        patch memo_path(memo)
+        expect(response).to redirect_to(login_path)
+      end
+    end
+    context "ログインしている場合" do
+      it "メモを更新できる" do
+        login_as(user)
 
-      patch memo_path(memo), params: {
-        memo: { title: "更新後タイトル" }
-      }
+        patch memo_path(memo), params: {
+          memo: { title: "更新後タイトル" }
+        }
 
-      expect(response).to redirect_to(memo_path(memo))
-      expect(memo.reload.title).to eq("更新後タイトル")
+        expect(response).to redirect_to(memo_path(memo))
+        expect(memo.reload.title).to eq("更新後タイトル")
+      end
     end
   end
   describe "DELETE /memos/:id(destroyのテスト)" do
-    it "メモを削除できる" do
-      login_as(user)
-      memo
-
-      expect {
+    context "未ログインの場合" do
+      it "login_pathにリダイレクトされる" do
         delete memo_path(memo)
-      }.to change(Memo, :count).by(-1)
-
-      expect(response).to redirect_to(memos_path)
+        expect(response).to redirect_to(login_path)
+      end
     end
-    it "memo削除時にif_then_ruleのmemo_idがnullになる" do
-      login_as(user)
-      memo
-      rule = create(:if_then_rule, user: user, memo: memo)
 
-      memo.destroy
+    context "ログインしている場合" do
+      it "メモを削除できる" do
+        login_as(user)
+        memo
 
-      expect(IfThenRule.exists?(rule.id)).to be true
-      expect(rule.reload.memo_id).to be_nil
+        expect {
+          delete memo_path(memo)
+        }.to change(Memo, :count).by(-1)
+
+        expect(response).to redirect_to(memos_path)
+      end
+      it "memo削除時にif_then_ruleのmemo_idがnullになる" do
+        login_as(user)
+        memo
+        rule = create(:if_then_rule, user: user, memo: memo)
+
+        memo.destroy
+
+        expect(IfThenRule.exists?(rule.id)).to be true
+        expect(rule.reload.memo_id).to be_nil
+      end
     end
   end
 
@@ -118,20 +135,22 @@ RSpec.describe "Memos", type: :request do
         login_as(user)
         get stale_memos_path
       end
-      let!(:my_memo) do
-        create(:memo, user: user, updated_at: 8.days.ago, title: "my memo")
-      end
+      context "8日以上前の取得されるメモがある場合" do
+        let!(:my_memo) do
+          create(:memo, user: user, updated_at: 8.days.ago, title: "my memo")
+        end
 
-      let!(:other_user_memo) do
-        create(:memo, user: other_user, updated_at: 8.days.ago, title: "other memo")
-      end
-      it "未整理のメモ一覧が表示される" do
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include("未整理メモ一覧")
-      end
-      it "他のユーザーのものが含まれない" do
-        expect(response.body).to include("my memo")
-        expect(response.body).not_to include("other memo")
+        let!(:other_user_memo) do
+          create(:memo, user: other_user, updated_at: 8.days.ago, title: "other memo")
+        end
+        it "未整理のメモ一覧が表示される" do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("未整理メモ一覧")
+        end
+        it "他のユーザーのものが含まれない" do
+          expect(response.body).to include("my memo")
+          expect(response.body).not_to include("other memo")
+        end
       end
     end
   end

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Memos", type: :request do
       let!(:my_memo) do
         create(:memo, user: user, updated_at: 8.days.ago, title: "my memo")
       end
-    
+
       let!(:other_user_memo) do
         create(:memo, user: other_user, updated_at: 8.days.ago, title: "other memo")
       end
@@ -134,8 +134,5 @@ RSpec.describe "Memos", type: :request do
         expect(response.body).not_to include("other memo")
       end
     end
-
-
-
   end
 end


### PR DESCRIPTION
## 概要
一定以上触れられてないメモをタグのように検索、ソートする機能
ただしransackを使用せずにかつ新たなルートとして作成。

Close #171 

## 実装内容
### 予定していた作業

- [x]  "未整理"(で放置されている)メモ用のscope作成



`stale`として一式追加
  - [x] ルート追加
  - [x] コントローラ追加
  - [x] ビュー追加 

- [x]  テスト追加



### 予定外だが実施した作業
- [x] memosリクエストスペックで#deleteや#newにおいてloginに関するテスト追加（重要度が高いため）

## 動作確認
- [x] memosから未整理のメモに絞るためのリンクをクリックすると未整理のメモの一覧に切り替わること 
- [x] 未整理のメモ一覧では文字列による検索がないこと(あると混乱を招くかもしれない)


## 備考
ルールに関しても未整理に当たるものを追加するか
あるいはステータスごとでのクリックでの検索切り替えを入れてもいいかもしれない。
#213 

メモの未整理に関しては
- 7日間更新されていないこと(updated_atが7日以上前)
- ルールがしていされていないこと
この二つの条件を満たすものを"未整理"(で放置されている)としている