### PR TITLE
fix:ransackを本番でも使えるように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :development, :test do
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
-  gem "ransack"
+
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
   gem "rspec-rails"
@@ -61,3 +61,4 @@ group :test do
 end
 
 gem "pundit", "~> 2.5"
+gem "ransack"


### PR DESCRIPTION

## 概要
fix:ransackを本番でも使えるように変更
Close #218 

## 実装内容
### 予定していた作業
- [x] Gemfileのransackの位置を移動

