### PR TITLE
Style/ルール一覧においてステータスのタグを状態に応じて色を変える

### DIFF
--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -32,4 +32,12 @@ class IfThenRule < ApplicationRecord
     when "habituated" then "定着済み"
     end
   end
+  def status_color_class
+    case status
+    when "draft" then " bg-teal-500 "
+    when "inactive" then " bg-gray-500 "
+    when "active" then " bg-sky-500 "
+    when "habituated" then " bg-slate-900 "
+    end
+  end
 end

--- a/app/views/if_then_rules/cards/_rule_actions_show.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_show.html.erb
@@ -1,0 +1,32 @@
+<div>
+      <!--ルールの元になったメモ-->
+    <div>
+      <% if rule.memo.present? %>
+      <div  class="bg-memo card rounded-lg shadow-sm">
+        <p class="text-[11px] text-gray-400 mt-1">
+          <%= rule.memo.title.presence || "（無題）" %>
+        </p>
+        <p class="text-[11px] text-gray-400 mt-1">
+          <%= rule.memo.body || "" %>
+        </p>
+      </div>
+      <% else %>
+        <p class="text-[11px] text-gray-400 mt-1">
+          元のメモがありません
+        </p>
+      <% end %>
+    </div>
+      <!--ボタン集-->
+      <div class="card-actions justify-end mt-4">
+        <%= link_to "編集",
+                    edit_if_then_rule_path(rule),
+                    class: "btn btn-ghost btn-sm btn-primary" %>
+        <%= link_to "削除",
+          if_then_rule_path(rule),
+          data: {
+                      turbo_method: :delete,
+                      turbo_confirm: "このルールを削除しますか？" },
+            class: "btn btn-ghost btn-error btn-sm"
+        %>
+      </div>
+</div>

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -2,7 +2,7 @@
 <div class=" <%= bg_class %>  card shadow-md rounded-lg  space-y-2 grid grid-rows-[1fr_0.6fr] relative">
     <!--ルールのステータス(表示したくない時はローカル引数show_statusをfalseへ)-->
     <% if local_assigns.fetch(:show_status, true) %>
-      <p class="tag bg-accent text-white inline-block  px-2.5 py-0.5 text-[10px] absolute top-2 right-2 rounded-lg opacity-80">
+      <p class="tag <%= rule.status_color_class %>text-white inline-block  px-2.5 py-0.5 text-[10px] absolute top-2 right-2 rounded-lg opacity-80">
         <%= rule.human_status%>
       </p>
     <% end %>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -5,7 +5,7 @@
 
     <div class="bg-base-100 card shadow-md rounded-lg  space-y-2 grid grid-rows-[1fr_0.6fr] relative ">
             <!--ルールのステータス-->
-            <p class="tag bg-accent text-white inline-block  px-2.5 py-0.5 text-[10px] absolute top-2 right-2 rounded-lg opacity-80">
+            <p class="tag <%= @if_then_rule.status_color_class %> text-white inline-block  px-2.5 py-0.5 text-[10px] absolute top-2 right-2 rounded-lg opacity-80">
               <%= @if_then_rule.human_status%>
             </p>
 

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -3,56 +3,6 @@
     <% end %>
 
 
-    <div class="bg-base-100 card shadow-md rounded-lg  space-y-2 grid grid-rows-[1fr_0.6fr] relative ">
-            <!--ルールのステータス-->
-            <p class="tag <%= @if_then_rule.status_color_class %> text-white inline-block  px-2.5 py-0.5 text-[10px] absolute top-2 right-2 rounded-lg opacity-80">
-              <%= @if_then_rule.human_status%>
-            </p>
-
-          <!--ルールのifとthenのグループ-->
-          <div class = " bg-base-100 p-4 rounded-t-lg shadow-inner ">
-            <%= render "if_then_rules/cards/rule_sentence", rule: @if_then_rule %>
-          </div>
-
-          <!--ルールのUI関係のグループ-->
-          <div >
-             
-              <!--ボタン集-->
-              <div class="card-actions justify-end mt-4">
-                <%= link_to "編集",
-                            edit_if_then_rule_path(@if_then_rule),
-                            class: "btn btn-ghost btn-sm btn-primary" %>
-                <%= link_to "削除",
-                  if_then_rule_path(@if_then_rule),
-                  data: {
-                              turbo_method: :delete,
-                              turbo_confirm: "このルールを削除しますか？" },
-                    class: "btn btn-ghost btn-error btn-sm"
-                %>
-              </div>
-        </div>
-    </div>
-
- <!--ルールの元になったメモ-->
-            <div class="bg-memo card shadow">
-              <% if @if_then_rule.memo.present? %>
-                <p class="text-[11px]  mt-1">
-                  元メモ：<%= @if_then_rule.memo.title.presence || "（無題）" %>
-                </p>
-                <p class="text-[11px] mt-1">
-                  <%= @if_then_rule.memo.body.presence || "（無題）" %>
-                </p>
-              <% else %>
-                <p class="text-[11px] text-gray-400 mt-1">
-                  元のメモがありません
-                </p>
-              <% end %>
-            </div>
-
-
-  <div>
-    <%= link_to "一覧に戻る",
-                if_then_rules_path,
-                class: "btn btn-ghost btn-sm" %>
-
-  </div>
+        <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100" do %>
+          <%= render "if_then_rules/cards/rule_actions_show",  rule: @if_then_rule %>
+        <% end %>


### PR DESCRIPTION
## 概要
ルール一覧においてステータスのタグを状態に応じて色を変える

Close #182 

## 実装内容
### 予定していた作業
- [x]  切り替え先の色の決定
    - [x]  未実行 灰色へ
    - [x]  下書き 緑に近い色へ
    - [x]  実行中 水色へ
    - [x]  定着済み 濃いめの灰色へ
- [x]  切り替えるための機構を実装(モデルへ)



### 予定外だが実施した作業
- [x] 詳細の表示の共通化(今後の編集をしやすくするため)

## 動作確認
- [x] 一覧表示でルールのステータスのバッジの色が変化していること 
- [x] 詳細表示でルールのステータスのバッジの色が変化していること 
 
 
 - 詳細表示に関してはもう少しその内容を吟味する必要性を感じる
 - ステータスごとにアイコンを入れたりあるいはバッジの形を変えるという選択肢もあったが重要度は低いので未実装