### PR TITLE
Feat/ルールの曜日による繰り返し機能の実装

### DIFF
--- a/app/controllers/dash_boards_controller.rb
+++ b/app/controllers/dash_boards_controller.rb
@@ -1,6 +1,8 @@
 class DashBoardsController < ApplicationController
   def index
-    @if_then_rules = policy_scope(IfThenRule)
+    @today_rules = policy_scope(IfThenRule).active.select(&:scheduled_today?)
+    puts "------------ids--------------------"
+    p @today_rules.map(&:id)
     authorize :dash_board
   end
 end

--- a/app/controllers/dash_boards_controller.rb
+++ b/app/controllers/dash_boards_controller.rb
@@ -1,8 +1,6 @@
 class DashBoardsController < ApplicationController
   def index
-    @today_rules = policy_scope(IfThenRule).active.select(&:scheduled_today?)
-    puts "------------ids--------------------"
-    p @today_rules.map(&:id)
+    @today_rules = policy_scope(IfThenRule).includes(:reflections).active.select(&:scheduled_today?)
     authorize :dash_board
   end
 end

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -23,6 +23,7 @@ class IfThenRulesController < ApplicationController
   end
 
   def create
+    # binding.b
     authorize IfThenRule
     sanitized_params = if_then_rule_params_with_permitted_memo
     @if_then_rule_form = IfThenRuleForm.new(sanitized_params, user: current_user)
@@ -78,7 +79,7 @@ class IfThenRulesController < ApplicationController
 
   def if_then_rule_params
     params.require(:if_then_rule_form)
-          .permit(:memo_id, :if_condition, :then_action, :status)
+          .permit(:memo_id, :if_condition, :then_action, :status, weekdays: [])
   end
 
   # 現在ユーザーがアクセス可能なメモのみを返す（memo_id の認可）

--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -13,13 +13,13 @@ class ReflectionsController < ApplicationController
     streams << turbo_stream.replace(
       "today_rules",
       partial: "if_then_rules/dash_boards/today_rules",
-      locals: { rules: policy_scope(IfThenRule).active.select(&:scheduled_today?) }
+      locals: { rules: policy_scope(IfThenRule).active.includes(:reflections).select(&:scheduled_today?) }
     )
 
     streams << turbo_stream.replace(
       "today_progress",
       partial: "if_then_rules/dash_boards/today_progress",
-      locals: { progress: today_progress(policy_scope(IfThenRule).active.select(&:scheduled_today?)) }
+      locals: { progress: today_progress(policy_scope(IfThenRule).active.includes(:reflections).select(&:scheduled_today?)) }
     )
 
     if current_user.all_rules_completed_today?
@@ -46,13 +46,13 @@ class ReflectionsController < ApplicationController
     streams << turbo_stream.replace(
       "today_rules",
       partial: "if_then_rules/dash_boards/today_rules",
-      locals: { rules: policy_scope(IfThenRule).active.select(&:scheduled_today?) }
+      locals: { rules: policy_scope(IfThenRule).active.includes(:reflections).select(&:scheduled_today?) }
     )
 
         streams << turbo_stream.replace(
       "today_progress",
       partial: "if_then_rules/dash_boards/today_progress",
-      locals: { progress: today_progress(policy_scope(IfThenRule).active.select(&:scheduled_today?)) }
+      locals: { progress: today_progress(policy_scope(IfThenRule).active.includes(:reflections).select(&:scheduled_today?)) }
     )
   render turbo_stream: streams, notice: "チェックを取り消ししました"
   end

--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -13,13 +13,13 @@ class ReflectionsController < ApplicationController
     streams << turbo_stream.replace(
       "today_rules",
       partial: "if_then_rules/dash_boards/today_rules",
-      locals: { rules: policy_scope(IfThenRule) }
+      locals: { rules: policy_scope(IfThenRule).active.select(&:scheduled_today?) }
     )
 
     streams << turbo_stream.replace(
       "today_progress",
       partial: "if_then_rules/dash_boards/today_progress",
-      locals: { progress: today_progress(policy_scope(IfThenRule)) }
+      locals: { progress: today_progress(policy_scope(IfThenRule).active.select(&:scheduled_today?)) }
     )
 
     if current_user.all_rules_completed_today?
@@ -46,13 +46,13 @@ class ReflectionsController < ApplicationController
     streams << turbo_stream.replace(
       "today_rules",
       partial: "if_then_rules/dash_boards/today_rules",
-      locals: { rules: policy_scope(IfThenRule) }
+      locals: { rules: policy_scope(IfThenRule).active.select(&:scheduled_today?) }
     )
 
         streams << turbo_stream.replace(
       "today_progress",
       partial: "if_then_rules/dash_boards/today_progress",
-      locals: { progress: today_progress(policy_scope(IfThenRule)) }
+      locals: { progress: today_progress(policy_scope(IfThenRule).active.select(&:scheduled_today?)) }
     )
   render turbo_stream: streams, notice: "チェックを取り消ししました"
   end

--- a/app/forms/if_then_rule_form.rb
+++ b/app/forms/if_then_rule_form.rb
@@ -21,7 +21,6 @@ class IfThenRuleForm
     @warnings = []
     @if_then_rule_of_model = if_then_rule_of_model
     @current_user = user
-
   end
 
 
@@ -116,7 +115,6 @@ end
       status: status,
       weekdays: weekdays
     )
-
   end
 
   def weekdays_must_be_valid_range

--- a/app/forms/if_then_rule_form.rb
+++ b/app/forms/if_then_rule_form.rb
@@ -11,7 +11,7 @@ class IfThenRuleForm
   # モデルにおいてstatusはintだがenum
   validates :if_condition, presence: { message: "IF（きっかけ）を入力してください" }, unless: -> { status == "draft" }
   validates :then_action, presence: { message: "THEN（行動）を入力してください" }, unless: -> { status == "draft" }
-
+  validate :weekdays_must_be_valid_range
   attr_reader :warnings
   attr_reader :user
   attr_reader :if_then_rule_of_model
@@ -117,5 +117,12 @@ end
       weekdays: weekdays
     )
 
+  end
+
+  def weekdays_must_be_valid_range
+    invalid = weekdays.reject { |d| (0..6).include?(d) }
+    return if invalid.empty?
+
+    errors.add(:weekdays, "に不正な値が含まれています")
   end
 end

--- a/app/forms/if_then_rule_form.rb
+++ b/app/forms/if_then_rule_form.rb
@@ -6,6 +6,8 @@ class IfThenRuleForm
   attribute :if_condition, :string
   attribute :then_action, :string
   attribute :status, :string
+  attribute :weekdays, default: []
+
   # モデルにおいてstatusはintだがenum
   validates :if_condition, presence: { message: "IF（きっかけ）を入力してください" }, unless: -> { status == "draft" }
   validates :then_action, presence: { message: "THEN（行動）を入力してください" }, unless: -> { status == "draft" }
@@ -19,6 +21,7 @@ class IfThenRuleForm
     @warnings = []
     @if_then_rule_of_model = if_then_rule_of_model
     @current_user = user
+
   end
 
   def valid?(context = nil)
@@ -86,7 +89,8 @@ class IfThenRuleForm
       memo_id: memo_id,
       if_condition: if_condition,
       then_action: then_action,
-      status: status
+      status: status,
+      weekdays: weekdays
     )
      record.persisted?
   end
@@ -96,7 +100,8 @@ class IfThenRuleForm
       memo_id: memo_id,
       if_condition: if_condition,
       then_action: then_action,
-      status: status
+      status: status,
+      weekdays: weekdays
     )
   end
 end

--- a/app/forms/if_then_rule_form.rb
+++ b/app/forms/if_then_rule_form.rb
@@ -24,6 +24,19 @@ class IfThenRuleForm
 
   end
 
+
+# ActiveModelのattribute :weekdaysの背後にあるセッター相当のものを上書きして入口だけ使用してparams代入に使いつつ独自の中身にする。
+# 中では並び替えとか重複削除しつつ毎日(7個分)を空配列に統一
+# ->既存データは空配列のまま毎日扱いにしつつ、毎日扱いのデータの種類を空配列のみの一種類にする
+def weekdays=(value)
+  days = Array(value).map(&:to_i).uniq.sort
+  @weekdays = days.size == 7 ? [] : days
+end
+
+def weekdays
+  @weekdays || []
+end
+
   def valid?(context = nil)
     result = super
     collect_warnings
@@ -103,5 +116,6 @@ class IfThenRuleForm
       status: status,
       weekdays: weekdays
     )
+
   end
 end

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -1,7 +1,7 @@
 module IfThenRulesHelper
   # ダッシュボードの"今日の達成率"で使用するヘルパー
-  def today_progress(if_then_rules)
-    active = if_then_rules.active
+  def today_progress(today_rules)
+    active = today_rules
     total  = active.count
     done   = active.count(&:reflected_today?)
 

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -24,6 +24,24 @@ class IfThenRule < ApplicationRecord
     reflections.find_by(reflected_on: Date.current)
   end
 
+
+  # 引数の曜日が設定された曜日にあるのか？
+  def scheduled_for?(date)
+    return true if weekdays.empty? # 空なら毎日扱い
+
+    weekdays.include?(date.wday)
+  end
+
+  # 今日用
+  def scheduled_today?
+    scheduled_for?(Date.current)
+  end
+
+  # 昨日の未達成のもののロジックを必要なら入れるただこのままだとn+1のおそれあり
+  # def unfinished_yesterday?
+    # scheduled_for?(Date.yesterday) && !!rule.reflections.exists?(reflected_on: Date.yesterday)
+  # end
+
   def human_status
     case status
     when "draft" then "下書き"

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -39,7 +39,7 @@ class IfThenRule < ApplicationRecord
 
   # 昨日の未達成のもののロジックを必要なら入れるただこのままだとn+1のおそれあり
   # def unfinished_yesterday?
-    # scheduled_for?(Date.yesterday) && !!rule.reflections.exists?(reflected_on: Date.yesterday)
+  # scheduled_for?(Date.yesterday) && !!rule.reflections.exists?(reflected_on: Date.yesterday)
   # end
 
   def human_status

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -17,7 +17,7 @@ class IfThenRule < ApplicationRecord
   end
 
   def reflected_today?
-  reflections.exists?(reflected_on: Date.current)
+  reflections.any? { |r| r.reflected_on == Date.current }
   end
 
   def today_reflection

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -1,14 +1,14 @@
-  <% if @if_then_rules.active.any? %>
+  <% if @today_rules.any? %>
     <% content_for :title do %>
       今日のルール
     <% end %>
     <!--今日のルール一覧-->
     <turbo-frame id="today_rules">
-    <%= render "if_then_rules/dash_boards/today_rules", rules: @if_then_rules %>
+    <%= render "if_then_rules/dash_boards/today_rules", rules: @today_rules %>
     </turbo-frame>
     <!-- カードの下の今日やったルールなどの集計表示 -->
     <turbo-frame id="today_progress">
-    <%= render "if_then_rules/dash_boards/today_progress", progress: today_progress(@if_then_rules) %>
+    <%= render "if_then_rules/dash_boards/today_progress", progress: today_progress(@today_rules) %>
     </turbo-frame>
 
     <div class="mt-12 flex flex-col gap-3">

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -81,6 +81,26 @@
       <%= f.collection_select :memo_id, current_user.memos, :id, :display_for_select, include_blank: true %>
     <% end %>
 
+
+    <!--曜日ごとの繰り返しの設定など-->
+    <details>
+    <summary>
+      曜日の繰り返し設定
+    </summary>
+    <% Date::DAYNAMES.each_with_index do |day, i| %>
+      <label>
+      <%= check_box_tag(
+        "if_then_rule_form[weekdays][]",
+        i,
+        if_then_rule_form.weekdays.map(&:to_i).include?(i)
+        ) %>
+        <%= I18n.t('date.day_names')[i] %>
+        </label>
+        <% end %>
+    </details>
+        
+
+
     <!--保存ボタンなど-->
     <div class="pt-4 space-y-3">
       <% if if_then_rule_form.warnings.present? %>

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -15,4 +15,6 @@
   <!--ルールのUI関係のグループ ブロックをわたす。-->
  
     <%= yield %>
+    <%=  rule.weekdays.blank? ? "毎日" : rule.weekdays.map { |i| I18n.t('date.abbr_day_names')[i] }.join("・") %>
+
 </div>

--- a/app/views/if_then_rules/dash_boards/_today_rules.html.erb
+++ b/app/views/if_then_rules/dash_boards/_today_rules.html.erb
@@ -1,7 +1,7 @@
 <!--ダッシュボードで使用する今日のルール一覧のパーシャル-->
 <turbo-frame id="today_rules">
   <div class="space-y-2">
-    <% rules.active.each do |rule| %>
+    <% rules.each do |rule| %>
 
     <!--card-->
       <%= render "if_then_rules/cards/rule_card",  rule: rule,bg_class: rule.reflected_today? ? "bg-base-300 " : "bg-base-100" , show_status: false do %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,11 @@ Rails.application.configure do
     Bullet.console       = true
     Bullet.rails_logger  = true
     Bullet.add_footer    = true
+    Bullet.add_safelist(
+  type: :unused_eager_loading,
+  class_name: "IfThenRule",
+  association: :reflections
+)
   end
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/db/migrate/20260228011923_add_weekdays_to_if_then_rules.rb
+++ b/db/migrate/20260228011923_add_weekdays_to_if_then_rules.rb
@@ -1,0 +1,5 @@
+class AddWeekdaysToIfThenRules < ActiveRecord::Migration[7.2]
+  def change
+    add_column :if_then_rules, :weekdays, :integer, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_16_045654) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_28_011923) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_16_045654) do
     t.bigint "memo_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "weekdays", default: [], null: false, array: true
     t.index ["memo_id"], name: "index_if_then_rules_on_memo_id"
     t.index ["user_id"], name: "index_if_then_rules_on_user_id"
   end

--- a/spec/forms/if_then_rule_form_spec.rb
+++ b/spec/forms/if_then_rule_form_spec.rb
@@ -14,28 +14,39 @@ RSpec.describe IfThenRuleForm, type: :model do
   )
 end
   describe "#valid?について" do
-    it "if_condition と then_action があれば valid" do
-      form = IfThenRuleForm.new(
-        { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1 },
-        user: user
-      )
-      expect(form).to be_valid
+  describe "正しい場合のバリデーション" do
+    context "if_condition と then_action があれば" do
+      it "valid" do
+        form = IfThenRuleForm.new(
+          { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1, weekdays: [] },
+          user: user
+          )
+          expect(form).to be_valid
+        end
+      end
+    end
+    describe "if_conditionのバリデーション" do
+      context "if_condition が空だと " do
+        it "invalid" do
+          form = IfThenRuleForm.new(
+            { if_condition: "", then_action: "水を飲む", memo_id: 1 },
+            user: user
+            )
+            expect(form).not_to be_valid
+        end
+      end
     end
 
-    it "if_condition が空だと invalid" do
-      form = IfThenRuleForm.new(
-        { if_condition: "", then_action: "水を飲む", memo_id: 1 },
-        user: user
-      )
-      expect(form).not_to be_valid
-    end
-
-    it "then_action が空だと invalid" do
-      form = IfThenRuleForm.new(
-        { if_condition: "朝起きたら", then_action: "", memo_id: 1 },
-        user: user
-      )
-      expect(form).not_to be_valid
+    describe "then_actionのバリデーション" do
+      context "then_action が空だと " do
+        it "invalid" do
+          form = IfThenRuleForm.new(
+            { if_condition: "朝起きたら", then_action: "", memo_id: 1 },
+            user: user
+          )
+          expect(form).not_to be_valid
+        end
+      end
     end
 
     describe "weekdaysのバリデーション" do

--- a/spec/forms/if_then_rule_form_spec.rb
+++ b/spec/forms/if_then_rule_form_spec.rb
@@ -365,4 +365,32 @@ end
       end
     end
   end
+
+  describe "weekdaysの正規化" do
+    context "7個選択した場合" do
+      it "空配列に正規化される" do
+        form = described_class.new(
+          { weekdays: %w[0 1 2 3 4 5 6] },
+          user: user
+        )
+
+        expect(form.weekdays).to eq([])
+      end
+    end
+    context "文字列として渡された(paramsの特性)場合" do
+      it "整数配列になる" do
+        form = described_class.new(
+          {
+          if_condition: "常に",
+          then_action: "水を飲む",
+          memo_id: memo.id,
+          weekdays: %w[1 3] },
+          user: user
+        )
+
+        expect(form.weekdays).to eq([1, 3])
+      end
+    end
+  end
+
 end

--- a/spec/forms/if_then_rule_form_spec.rb
+++ b/spec/forms/if_then_rule_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe IfThenRuleForm, type: :model do
     status: "draft"
   )
 end
-  describe "#valid?の本来のバリデーションの役目" do
+  describe "#valid?について" do
     it "if_condition と then_action があれば valid" do
       form = IfThenRuleForm.new(
         { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1 },
@@ -37,6 +37,33 @@ end
       )
       expect(form).not_to be_valid
     end
+
+    describe "weekdaysについて" do
+      context "0〜6のみの場合は" do
+        it "valid" do
+          form = described_class.new(
+            { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1 ,weekdays: %w[0 3 6] },
+            user: user
+          )
+
+          expect(form).to be_valid
+        end
+      end
+      context "0〜6以外の場合は" do
+        it "invalid" do
+            form = described_class.new(
+              { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1 ,weekdays: %w[0 7] },
+              user: user
+            )
+
+            expect(form).not_to be_valid
+            expect(form.errors[:weekdays]).to include("に不正な値が含まれています")
+        end
+      end
+
+    end
+
+
   end
   describe "#valid?で追加されるwarningsの機能" do
     context "適切な値の時" do

--- a/spec/forms/if_then_rule_form_spec.rb
+++ b/spec/forms/if_then_rule_form_spec.rb
@@ -391,6 +391,20 @@ end
         expect(form.weekdays).to eq([1, 3])
       end
     end
+    context "重複している場合" do
+      it "重複部分が削除される" do
+        form = described_class.new(
+          {
+          if_condition: "常に",
+          then_action: "水を飲む",
+          memo_id: memo.id,
+          weekdays: %w[1 3 3] },
+          user: user
+        )
+
+        expect(form.weekdays).to eq([1, 3])
+      end
+    end
   end
 
 end

--- a/spec/forms/if_then_rule_form_spec.rb
+++ b/spec/forms/if_then_rule_form_spec.rb
@@ -53,7 +53,7 @@ end
       context "0〜6のみの場合は" do
         it "valid" do
           form = described_class.new(
-            { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1 ,weekdays: %w[0 3 6] },
+            { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1, weekdays: %w[0 3 6] },
             user: user
           )
 
@@ -63,7 +63,7 @@ end
       context "0〜6以外の場合は" do
         it "invalid" do
             form = described_class.new(
-              { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1 ,weekdays: %w[0 7] },
+              { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1, weekdays: %w[0 7] },
               user: user
             )
 
@@ -71,18 +71,16 @@ end
             expect(form.errors[:weekdays]).to include("に不正な値が含まれています")
         end
       end
-      context  "空配列の場合" do
+      context "空配列の場合" do
         it "有効（毎日扱い）" do
           form = described_class.new(
-            { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1 ,weekdays: [] },
+            { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1, weekdays: [] },
             user: user
           )
           expect(form).to be_valid
         end
       end
     end
-
-
   end
   describe "#valid?で追加されるwarningsの機能" do
     context "適切な値の時" do
@@ -388,7 +386,7 @@ end
           user: user
         )
 
-        expect(form.weekdays).to eq([1, 3])
+        expect(form.weekdays).to eq([ 1, 3 ])
       end
     end
     context "重複している場合" do
@@ -402,9 +400,8 @@ end
           user: user
         )
 
-        expect(form.weekdays).to eq([1, 3])
+        expect(form.weekdays).to eq([ 1, 3 ])
       end
     end
   end
-
 end

--- a/spec/forms/if_then_rule_form_spec.rb
+++ b/spec/forms/if_then_rule_form_spec.rb
@@ -38,7 +38,7 @@ end
       expect(form).not_to be_valid
     end
 
-    describe "weekdaysについて" do
+    describe "weekdaysのバリデーション" do
       context "0〜6のみの場合は" do
         it "valid" do
           form = described_class.new(
@@ -60,7 +60,15 @@ end
             expect(form.errors[:weekdays]).to include("に不正な値が含まれています")
         end
       end
-
+      context  "空配列の場合" do
+        it "有効（毎日扱い）" do
+          form = described_class.new(
+            { if_condition: "朝起きたら", then_action: "水を飲む", memo_id: 1 ,weekdays: [] },
+            user: user
+          )
+          expect(form).to be_valid
+        end
+      end
     end
 
 

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe IfThenRule, type: :model do
       expect(if_then_rule.errors[:status]).to include("を入力してください")
     end
   end
-  describe "便利系メソッド関連" do
+  describe "メソッド関連" do
     let(:rule) { create(:if_then_rule, user: user, memo: memo) }
 
 
@@ -88,6 +88,35 @@ RSpec.describe IfThenRule, type: :model do
       context "今日のreflectionがない場合" do
         it "nilを返す" do
           expect(rule.today_reflection).to be nil
+        end
+      end
+    end
+
+    describe "#scheduled_for?" do
+      context "weekdays が空の場合" do
+        it "どの曜日でもtrue" do
+          rule = create(:if_then_rule, user: user, memo: memo, weekdays: [])
+
+          expect(rule.scheduled_for?(Date.new(2026,3,2))).to be true
+          expect(rule.scheduled_for?(Date.new(2026,3,3))).to be true
+        end
+      end
+      context "weekdaysを設定されている場合" do
+        context "設定と一致する日なら" do
+          it "trueを返す" do
+            rule = create(:if_then_rule, user: user, memo: memo, weekdays: [1]) # 月曜
+
+            monday = Date.new(2026,3,2) # 月曜
+            expect(rule.scheduled_for?(monday)).to be true
+          end
+        end
+        context "設定と一致しない日なら" do
+          it "falseを返す" do
+            rule = create(:if_then_rule, user: user, memo: memo, weekdays: [1]) # 月曜
+
+            tuesday = Date.new(2026,3,3)
+            expect(rule.scheduled_for?(tuesday)).to be false
+          end
         end
       end
     end

--- a/spec/models/if_then_rule_spec.rb
+++ b/spec/models/if_then_rule_spec.rb
@@ -97,24 +97,24 @@ RSpec.describe IfThenRule, type: :model do
         it "どの曜日でもtrue" do
           rule = create(:if_then_rule, user: user, memo: memo, weekdays: [])
 
-          expect(rule.scheduled_for?(Date.new(2026,3,2))).to be true
-          expect(rule.scheduled_for?(Date.new(2026,3,3))).to be true
+          expect(rule.scheduled_for?(Date.new(2026, 3, 2))).to be true
+          expect(rule.scheduled_for?(Date.new(2026, 3, 3))).to be true
         end
       end
       context "weekdaysを設定されている場合" do
         context "設定と一致する日なら" do
           it "trueを返す" do
-            rule = create(:if_then_rule, user: user, memo: memo, weekdays: [1]) # 月曜
+            rule = create(:if_then_rule, user: user, memo: memo, weekdays: [ 1 ]) # 月曜
 
-            monday = Date.new(2026,3,2) # 月曜
+            monday = Date.new(2026, 3, 2) # 月曜
             expect(rule.scheduled_for?(monday)).to be true
           end
         end
         context "設定と一致しない日なら" do
           it "falseを返す" do
-            rule = create(:if_then_rule, user: user, memo: memo, weekdays: [1]) # 月曜
+            rule = create(:if_then_rule, user: user, memo: memo, weekdays: [ 1 ]) # 月曜
 
-            tuesday = Date.new(2026,3,3)
+            tuesday = Date.new(2026, 3, 3)
             expect(rule.scheduled_for?(tuesday)).to be false
           end
         end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')
   ]
-
+  config.include ActiveSupport::Testing::TimeHelpers
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/system/rule_weekdays_spec.rb
+++ b/spec/system/rule_weekdays_spec.rb
@@ -41,19 +41,7 @@ RSpec.describe "Rule Weekdays", type: :system do
   describe "ルール編集での曜日再設定をできる" do
     it "曜日を編集して変更できる" do
 
-      visit step1_if_then_rules_flow_path
-      click_link "このメモから作る"
-
-      fill_in "if_then_rule_form_if_condition", with: "朝起きたら"
-      fill_in "if_then_rule_form_then_action", with: "腕立て伏せ3回する"
-      check "commit_type"
-
-      find("summary", text: "曜日の繰り返し設定").click
-      check "月曜日"
-      check "水曜日"
-
-      click_button "保存する"
-      expect(page).to have_content("作成しました")
+      create(:if_then_rule, user:user, memo: memo, weekdays: [1,3])
       visit if_then_rules_path
       expect(page).to have_content("If-Thenルール一覧")
       expect(page).to have_content("月・水")
@@ -119,6 +107,37 @@ RSpec.describe "Rule Weekdays", type: :system do
       expect(page).to have_content("毎日")
     end
   end
+  describe "ダッシュボードで曜日が適切に機能する" do
+    context "作成したルールに特定の曜日がある場合" do
 
+      it "設定曜日の日だけ表示される" do
+        travel_to Date.new(2026, 3, 2) # 月曜日
+        rule = create(:if_then_rule, user:user, memo: memo, weekdays: [1], status: :active) #月曜日
+        visit dash_boards_path
+        p Time.now
+        expect(page).to have_content(rule.if_condition)
+      end
+      it "設定曜日の日ではない日だと表示されない" do
+        travel_to Date.new(2026, 3, 1) # 日曜日
+        rule = create(:if_then_rule, user:user, memo: memo, weekdays: [1], status: :active) #月曜日
+        visit dash_boards_path
+        p Time.now
+        expect(page).not_to have_content(rule.if_condition)
+      end
+    end
+    context "作成したルールに毎日相当の設定の場合" do
+
+      it "表示される" do
+        travel_to Date.new(2026, 3, 2) # 月曜日
+      
+        rule = create(:if_then_rule, user:user, memo: memo, status: :active)
+      
+        visit dash_boards_path
+        p Time.now
+        expect(page).to have_content(rule.if_condition)
+      end
+    end
+
+  end
 
 end

--- a/spec/system/rule_weekdays_spec.rb
+++ b/spec/system/rule_weekdays_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 RSpec.describe "Rule Weekdays", type: :system do
-
   let!(:user) { create(:user) }
   let!(:memo) { create(:memo, user: user) }
 
@@ -18,7 +17,6 @@ RSpec.describe "Rule Weekdays", type: :system do
 
   describe "ルール作成での曜日設定をできる" do
     it "曜日を設定できる" do
-
       visit step1_if_then_rules_flow_path
       click_link "このメモから作る"
 
@@ -35,37 +33,33 @@ RSpec.describe "Rule Weekdays", type: :system do
       visit if_then_rules_path
       expect(page).to have_content("If-Thenルール一覧")
       expect(page).to have_content("月・水")
-
     end
   end
   describe "ルール編集での曜日再設定をできる" do
     it "曜日を編集して変更できる" do
-
-      create(:if_then_rule, user:user, memo: memo, weekdays: [1,3])
+      create(:if_then_rule, user: user, memo: memo, weekdays: [ 1, 3 ])
       visit if_then_rules_path
       expect(page).to have_content("If-Thenルール一覧")
       expect(page).to have_content("月・水")
-      
+
       click_link "編集"
       expect(page).to have_content("If-Thenルール編集")
-      
+
       check "commit_type"
-      
+
       find("summary", text: "曜日の繰り返し設定").click
       check "火曜日"
       check "日曜日"
-      
+
       click_button "保存する"
-      
+
       expect(page).to have_content("編集しました")
 
       expect(page).not_to have_content("月・水")
     end
   end
   describe "表示関連" do
-
     it "未入力で毎日と表示される" do
-
       visit step1_if_then_rules_flow_path
       click_link "このメモから作る"
 
@@ -83,7 +77,6 @@ RSpec.describe "Rule Weekdays", type: :system do
       expect(page).to have_content("毎日")
     end
     it "全ての曜日入力で毎日と表示される" do
-
       visit step1_if_then_rules_flow_path
       click_link "このメモから作る"
 
@@ -109,35 +102,31 @@ RSpec.describe "Rule Weekdays", type: :system do
   end
   describe "ダッシュボードで曜日が適切に機能する" do
     context "作成したルールに特定の曜日がある場合" do
-
       it "設定曜日の日だけ表示される" do
         travel_to Date.new(2026, 3, 2) # 月曜日
-        rule = create(:if_then_rule, user:user, memo: memo, weekdays: [1], status: :active) #月曜日
+        rule = create(:if_then_rule, user: user, memo: memo, weekdays: [ 1 ], status: :active) # 月曜日
         visit dash_boards_path
         p Time.now
         expect(page).to have_content(rule.if_condition)
       end
       it "設定曜日の日ではない日だと表示されない" do
         travel_to Date.new(2026, 3, 1) # 日曜日
-        rule = create(:if_then_rule, user:user, memo: memo, weekdays: [1], status: :active) #月曜日
+        rule = create(:if_then_rule, user: user, memo: memo, weekdays: [ 1 ], status: :active) # 月曜日
         visit dash_boards_path
         p Time.now
         expect(page).not_to have_content(rule.if_condition)
       end
     end
     context "作成したルールに毎日相当の設定の場合" do
-
       it "表示される" do
         travel_to Date.new(2026, 3, 2) # 月曜日
-      
-        rule = create(:if_then_rule, user:user, memo: memo, status: :active)
-      
+
+        rule = create(:if_then_rule, user: user, memo: memo, status: :active)
+
         visit dash_boards_path
         p Time.now
         expect(page).to have_content(rule.if_condition)
       end
     end
-
   end
-
 end

--- a/spec/system/rule_weekdays_spec.rb
+++ b/spec/system/rule_weekdays_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+RSpec.describe "Rule Weekdays", type: :system do
+
+  let!(:user) { create(:user) }
+  let!(:memo) { create(:memo, user: user) }
+
+
+  before do
+    visit login_path
+    expect(page).to have_content("ログイン")
+    fill_in "session_email", with: user.email
+    fill_in "session_password", with: "password"
+    click_button "commit"
+
+    expect(page).to have_content("ログインが成功しました")
+  end
+
+
+  describe "ルール作成での曜日設定をできる" do
+    it "曜日を設定できる" do
+
+      visit step1_if_then_rules_flow_path
+      click_link "このメモから作る"
+
+      fill_in "if_then_rule_form_if_condition", with: "朝起きたら"
+      fill_in "if_then_rule_form_then_action", with: "腕立て伏せ3回する"
+      check "commit_type"
+
+      find("summary", text: "曜日の繰り返し設定").click
+      check "月曜日"
+      check "水曜日"
+
+      click_button "保存する"
+      expect(page).to have_content("作成しました")
+      visit if_then_rules_path
+      expect(page).to have_content("If-Thenルール一覧")
+      expect(page).to have_content("月・水")
+
+    end
+  end
+  describe "ルール編集での曜日再設定をできる" do
+    it "曜日を編集して変更できる" do
+
+      visit step1_if_then_rules_flow_path
+      click_link "このメモから作る"
+
+      fill_in "if_then_rule_form_if_condition", with: "朝起きたら"
+      fill_in "if_then_rule_form_then_action", with: "腕立て伏せ3回する"
+      check "commit_type"
+
+      find("summary", text: "曜日の繰り返し設定").click
+      check "月曜日"
+      check "水曜日"
+
+      click_button "保存する"
+      expect(page).to have_content("作成しました")
+      visit if_then_rules_path
+      expect(page).to have_content("If-Thenルール一覧")
+      expect(page).to have_content("月・水")
+      
+      click_link "編集"
+      expect(page).to have_content("If-Thenルール編集")
+      
+      check "commit_type"
+      
+      find("summary", text: "曜日の繰り返し設定").click
+      check "火曜日"
+      check "日曜日"
+      
+      click_button "保存する"
+      
+      expect(page).to have_content("編集しました")
+
+      expect(page).not_to have_content("月・水")
+    end
+  end
+  describe "表示関連" do
+
+    it "未入力で毎日と表示される" do
+
+      visit step1_if_then_rules_flow_path
+      click_link "このメモから作る"
+
+      fill_in "if_then_rule_form_if_condition", with: "朝起きたら"
+      fill_in "if_then_rule_form_then_action", with: "腕立て伏せ3回する"
+      check "commit_type"
+
+      find("summary", text: "曜日の繰り返し設定").click
+
+
+      click_button "保存する"
+
+      visit if_then_rules_path
+      expect(page).to have_content("If-Thenルール一覧")
+      expect(page).to have_content("毎日")
+    end
+    it "全ての曜日入力で毎日と表示される" do
+
+      visit step1_if_then_rules_flow_path
+      click_link "このメモから作る"
+
+      fill_in "if_then_rule_form_if_condition", with: "朝起きたら"
+      fill_in "if_then_rule_form_then_action", with: "腕立て伏せ3回する"
+      check "commit_type"
+
+      find("summary", text: "曜日の繰り返し設定").click
+      check "月曜日"
+      check "火曜日"
+      check "水曜日"
+      check "木曜日"
+      check "金曜日"
+      check "土曜日"
+      check "日曜日"
+
+      click_button "保存する"
+
+      visit if_then_rules_path
+      expect(page).to have_content("If-Thenルール一覧")
+      expect(page).to have_content("毎日")
+    end
+  end
+
+
+end


### PR DESCRIPTION

## 概要
ルールの曜日による繰り返し機能実装

Close #170 

## 実装内容
### 予定していた作業
- [x]  マイグレーションの作成
- [x]  今日が曜日の日に該当するかのロジック作成
- [x]  フォームから曜日を設定できる機能追加
- [x]  ダッシュボードで曜日ロジックに基づいて表示できる機能追加
- [x]  テストの追加



### 予定外だが実施した作業
- [x]  ビューでしていたactiveでの絞り込みをコントローラーで行う
- [x]  reflections_controllerでもローカル引数に新たな形式として渡す
- [x]  `exist?`だとincludesがあってもn+1になるので`any?`に変更
- [x]  バリデーションを追加
- [x]  以前のテストの構成を少し書き直し

## 動作確認
- [x]  入力して設定できる
    - [x]  ルールの新規作成で曜日を設定できる
    - [x]  ルールの編集で曜日を変更できる
- [x]  設定したものを確認できる
    - [x]  ダッシュボードで曜日が見られる?
        - [x]  設定した曜日が見られる
        - [x]  空配列の場合”毎日”
        - [x]  7個入れた場合も”毎日”
    - [x]  ダッシュボードで機能する
        - [x]  ダッシュボードで曜日設定した場合
            - [x]  設定曜日でのみ表示される
            - [x]  設定曜日でない場合は表示されない
        - [x]  毎日に相当する設定の場合表示される
<img width="588" height="533" alt="image" src="https://github.com/user-attachments/assets/1e0a1cb9-06e0-4ee5-a091-fece879b2b65" />


## 備考
### 今後やってもいいかも
曜日のUIは直すべき
- [ ]  クエリとして切り出してdash_boardsとreflecionsで共有
- [ ]  現在n+1問題発生している可能性がある？この辺りの再設計は別イシューへ
- [ ]  昨日の未達成のルールロジック
- [ ]  ダッシュボードに表示するものをsqlでの検索にする？