### PR TITLE
Style/曜日での設定機能のui調整

### DIFF
--- a/app/forms/if_then_rule_form.rb
+++ b/app/forms/if_then_rule_form.rb
@@ -65,6 +65,7 @@ end
       self.if_condition = if_then_rule_of_model.if_condition
       self.then_action  = if_then_rule_of_model.then_action
       self.status  = if_then_rule_of_model.status
+      self.weekdays  = if_then_rule_of_model.weekdays
   end
 
   # ↓ビュー(_form.html.erb)で使うwarningメッセージ集を取得するためのメソッド。

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -20,4 +20,14 @@ module IfThenRulesHelper
     # activeなルールの個数が3つ以上あれば初期値をdraftにする
     active_if_then_rules.length >= 3 ? "draft" : "active"
   end
+
+# ステータスのバッジ表示においてその色をステータスごとに変えるヘルパー
+  def status_color_class(status)
+    case status
+    when "draft" then " bg-teal-500 "
+    when "inactive" then " bg-gray-500 "
+    when "active" then " bg-sky-500 "
+    when "habituated" then " bg-slate-900 "
+    end
+  end
 end

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -21,7 +21,7 @@ module IfThenRulesHelper
     active_if_then_rules.length >= 3 ? "draft" : "active"
   end
 
-# ステータスのバッジ表示においてその色をステータスごとに変えるヘルパー
+  # ステータスのバッジ表示においてその色をステータスごとに変えるヘルパー
   def status_color_class(status)
     case status
     when "draft" then " bg-teal-500 "

--- a/app/helpers/weekdays_helper.rb
+++ b/app/helpers/weekdays_helper.rb
@@ -2,13 +2,13 @@ module WeekdaysHelper
   # 毎日か設定されている曜日を配列に入れて返す
   # 空配列の場合"毎日"というところも対応
   def weekdays_labels(weekdays)
-    return ["毎日"] if weekdays.blank?
+    return [ "毎日" ] if weekdays.blank?
 
     t_names = I18n.t("date.abbr_day_names")
 
-    weekdays.map {|i| t_names[i]}
+    weekdays.map { |i| t_names[i] }
   end
-# 曜日の色の管理するハッシュから対応するクラス文字列を返す
+  # 曜日の色の管理するハッシュから対応するクラス文字列を返す
   def weekdays_bg_color(day)
     {
       "日" => "bg-red-100 text-red-700",
@@ -21,7 +21,7 @@ module WeekdaysHelper
       "毎日" => "bg-slate-500 text-white"
     }.fetch(day, "bg-base-200")
   end
-# フォームの曜日設定のフィールドのチェック時のクラス
+  # フォームの曜日設定のフィールドのチェック時のクラス
   def checked_weekday_class(index)
     [
       "peer-checked:bg-red-100 peer-checked:text-red-700 peer-checked:outline peer-checked:outline-2 peer-checked:outline-red-400 peer-checked:font-semibold",

--- a/app/helpers/weekdays_helper.rb
+++ b/app/helpers/weekdays_helper.rb
@@ -1,0 +1,13 @@
+module WeekdaysHelper
+
+  #曜日をカードで表示するためのヘルパー
+  # 毎日か設定されている曜日を表示する
+  def weekdays_label(weekdays)
+    return "毎日" if weekdays.blank?
+
+    t_names = I18n.t("date.abbr_day_names")
+
+    weekdays.map {|i| t_names[i]}.join("・")
+  end
+
+end

--- a/app/helpers/weekdays_helper.rb
+++ b/app/helpers/weekdays_helper.rb
@@ -1,13 +1,24 @@
 module WeekdaysHelper
-
-  #曜日をカードで表示するためのヘルパー
-  # 毎日か設定されている曜日を表示する
-  def weekdays_label(weekdays)
-    return "毎日" if weekdays.blank?
+  # 毎日か設定されている曜日を配列に入れて返す
+  # 空配列の場合"毎日"というところも対応
+  def weekdays_labels(weekdays)
+    return ["毎日"] if weekdays.blank?
 
     t_names = I18n.t("date.abbr_day_names")
 
-    weekdays.map {|i| t_names[i]}.join("・")
+    weekdays.map {|i| t_names[i]}
   end
-
+# 曜日の色の管理するハッシュから対応するクラス文字列を返す
+  def weekdays_bg_color(day)
+    {
+      "日" => "bg-red-100 text-red-700",
+      "月" => "bg-blue-100 text-blue-700",
+      "火" => "bg-orange-100 text-orange-700",
+      "水" => "bg-cyan-100 text-cyan-700",
+      "木" => "bg-emerald-100 text-emerald-700",
+      "金" => "bg-yellow-100 text-yellow-700",
+      "土" => "bg-purple-100 text-purple-700",
+      "毎日" => "bg-slate-500 text-white"
+    }.fetch(day, "bg-base-200")
+  end
 end

--- a/app/helpers/weekdays_helper.rb
+++ b/app/helpers/weekdays_helper.rb
@@ -21,4 +21,16 @@ module WeekdaysHelper
       "毎日" => "bg-slate-500 text-white"
     }.fetch(day, "bg-base-200")
   end
+# フォームの曜日設定のフィールドのチェック時のクラス
+  def checked_weekday_class(index)
+    [
+      "peer-checked:bg-red-100 peer-checked:text-red-700 peer-checked:outline peer-checked:outline-2 peer-checked:outline-red-400 peer-checked:font-semibold",
+      "peer-checked:bg-blue-100 peer-checked:text-blue-700 peer-checked:outline peer-checked:outline-2 peer-checked:outline-blue-400 peer-checked:font-semibold",
+      "peer-checked:bg-orange-100 peer-checked:text-orange-700 peer-checked:outline peer-checked:outline-2 peer-checked:outline-orange-400 peer-checked:font-semibold",
+      "peer-checked:bg-cyan-100 peer-checked:text-cyan-700 peer-checked:outline peer-checked:outline-2 peer-checked:outline-cyan-400 peer-checked:font-semibold",
+      "peer-checked:bg-emerald-100 peer-checked:text-emerald-700 peer-checked:outline peer-checked:outline-2 peer-checked:outline-emerald-400 peer-checked:font-semibold",
+      "peer-checked:bg-yellow-100 peer-checked:text-yellow-700 peer-checked:outline peer-checked:outline-2 peer-checked:outline-yellow-400 peer-checked:font-semibold",
+      "peer-checked:bg-purple-100 peer-checked:text-purple-700 peer-checked:outline peer-checked:outline-2 peer-checked:outline-purple-400 peer-checked:font-semibold"
+    ][index]
+  end
 end

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -50,12 +50,5 @@ class IfThenRule < ApplicationRecord
     when "habituated" then "定着済み"
     end
   end
-  def status_color_class
-    case status
-    when "draft" then " bg-teal-500 "
-    when "inactive" then " bg-gray-500 "
-    when "active" then " bg-sky-500 "
-    when "habituated" then " bg-slate-900 "
-    end
-  end
+
 end

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -50,5 +50,4 @@ class IfThenRule < ApplicationRecord
     when "habituated" then "定着済み"
     end
   end
-
 end

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -83,22 +83,7 @@
 
 
     <!--曜日ごとの繰り返しの設定など-->
-    <details>
-    <summary>
-      曜日の繰り返し設定
-    </summary>
-    <% Date::DAYNAMES.each_with_index do |day, i| %>
-      <label>
-      <%= check_box_tag(
-        "if_then_rule_form[weekdays][]",
-        i,
-        if_then_rule_form.weekdays.map(&:to_i).include?(i)
-        ) %>
-        <%= I18n.t('date.day_names')[i] %>
-        </label>
-        <% end %>
-    </details>
-        
+    <%= render "weekday_fields", form: f %>
 
 
     <!--保存ボタンなど-->

--- a/app/views/if_then_rules/_weekday_fields.html.erb
+++ b/app/views/if_then_rules/_weekday_fields.html.erb
@@ -1,0 +1,27 @@
+<details>
+<summary>
+  曜日の繰り返し設定
+</summary>
+
+    <div class="form-control">
+
+      <div class="flex gap-2 flex-wrap justify-center">
+        <% Date::DAYNAMES.each_with_index do |day, i| %>
+          <label class="flex items-center gap-1">
+            <%= check_box_tag(
+              "if_then_rule_form[weekdays][]",
+              i,
+              form.object.weekdays.map(&:to_i).include?(i),
+              {}
+            ) %>
+            <span><%= I18n.t('date.abbr_day_names')[i] %></span>
+          </label>
+        <% end %>
+      </div>
+
+      <p class="text-xs text-gray-500">
+        未指定の場合は毎日実行されます
+      </p>
+  </div>
+</details>
+    

--- a/app/views/if_then_rules/_weekday_fields.html.erb
+++ b/app/views/if_then_rules/_weekday_fields.html.erb
@@ -5,21 +5,30 @@
 
     <div class="form-control">
 
-      <div class="flex gap-2 flex-wrap justify-center">
-        <% Date::DAYNAMES.each_with_index do |day, i| %>
-          <label class="flex items-center gap-1">
-            <%= check_box_tag(
-              "if_then_rule_form[weekdays][]",
-              i,
-              form.object.weekdays.map(&:to_i).include?(i),
-              {}
-            ) %>
-            <span><%= I18n.t('date.abbr_day_names')[i] %></span>
-          </label>
-        <% end %>
-      </div>
+    <div class="flex gap-2 flex-wrap justify-center">
 
-      <p class="text-xs text-gray-500">
+    <% Date::DAYNAMES.each_with_index do |day, i| %>
+  
+      <label class="cursor-pointer">
+  
+        <%= check_box_tag(
+          "if_then_rule_form[weekdays][]",
+          i,
+          form.object.weekdays.map(&:to_i).include?(i),
+          class: "peer hidden"
+        ) %>
+  
+        <span class="badge px-3 py-2 border rounded-lg text-gray-500 transition <%= checked_weekday_class(i) %> hover:bg-base-300 ">
+          <%= I18n.t("date.abbr_day_names")[i] %>
+        </span>
+  
+      </label>
+  
+    <% end %>
+  
+  </div>
+
+      <p class="text-xs text-gray-500 ">
         未指定の場合は毎日実行されます
       </p>
   </div>

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -15,6 +15,6 @@
   <!--ルールのUI関係のグループ ブロックをわたす。-->
  
     <%= yield %>
-    <%=  rule.weekdays.blank? ? "毎日" : rule.weekdays.map { |i| I18n.t('date.abbr_day_names')[i] }.join("・") %>
+    <%=   weekdays_label(rule.weekdays) %>
 
 </div>

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -2,7 +2,7 @@
 <div class=" <%= bg_class %>  card shadow-md rounded-lg  space-y-2 grid grid-rows-[1fr_0.6fr] relative">
     <!--ルールのステータス(表示したくない時はローカル引数show_statusをfalseへ)-->
     <% if local_assigns.fetch(:show_status, true) %>
-      <p class="tag <%= rule.status_color_class %>text-white inline-block  px-2.5 py-0.5 text-[10px] absolute top-2 right-2 rounded-lg opacity-80">
+      <p class="tag <%= status_color_class(rule.status) %>text-white inline-block  px-2.5 py-0.5 text-[10px] absolute top-2 right-2 rounded-lg opacity-80">
         <%= rule.human_status%>
       </p>
     <% end %>
@@ -15,6 +15,12 @@
   <!--ルールのUI関係のグループ ブロックをわたす。-->
  
     <%= yield %>
-    <%=   weekdays_label(rule.weekdays) %>
+    <div class="flex flex-wrap gap-1 text-sm">
+      <% weekdays_labels(rule.weekdays).each do |day| %>
+        <span class="badge rounded-lg <%= weekdays_bg_color(day) %>">
+          <%= day %>
+        </span>
+      <% end %>
+    </div>
 
 </div>

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -10,17 +10,12 @@
   <!--ルールのifとthenのグループ-->
   <div class = "  p-4 rounded-t-lg ">
     <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
-  </div>
-
-  <!--ルールのUI関係のグループ ブロックをわたす。-->
- 
-    <%= yield %>
-    <div class="flex flex-wrap gap-1 text-sm">
-      <% weekdays_labels(rule.weekdays).each do |day| %>
-        <span class="badge rounded-lg <%= weekdays_bg_color(day) %>">
-          <%= day %>
-        </span>
-      <% end %>
     </div>
+    
+    <!--ルールのUI関係のグループ ブロックをわたす。-->
+    
+    <%= yield %>
+    <%= render "if_then_rules/cards/rule_weekdays", weekdays: rule.weekdays %>
+
 
 </div>

--- a/app/views/if_then_rules/cards/_rule_weekdays.html.erb
+++ b/app/views/if_then_rules/cards/_rule_weekdays.html.erb
@@ -1,0 +1,7 @@
+<div class="flex flex-wrap gap-1 text-sm">
+  <% weekdays_labels(weekdays).each do |day| %>
+    <span class="badge rounded-lg <%= weekdays_bg_color(day) %>">
+      <%= day %>
+    </span>
+  <% end %>
+</div>

--- a/spec/system/rule_weekdays_spec.rb
+++ b/spec/system/rule_weekdays_spec.rb
@@ -25,22 +25,24 @@ RSpec.describe "Rule Weekdays", type: :system do
       check "commit_type"
 
       find("summary", text: "曜日の繰り返し設定").click
-      check "月曜日"
-      check "水曜日"
+      find("label", text: "月").click
+      find("label", text: "水").click
 
       click_button "保存する"
       expect(page).to have_content("作成しました")
       visit if_then_rules_path
       expect(page).to have_content("If-Thenルール一覧")
-      expect(page).to have_content("月・水")
+      expect(page).to have_content("月")
+      expect(page).to have_content("水")
     end
   end
-  describe "ルール編集での曜日再設定をできる" do
+  describe "ルール編集での曜日再設定できる(追加)" do
     it "曜日を編集して変更できる" do
       create(:if_then_rule, user: user, memo: memo, weekdays: [ 1, 3 ])
       visit if_then_rules_path
       expect(page).to have_content("If-Thenルール一覧")
-      expect(page).to have_content("月・水")
+      expect(page).to have_content("月")
+      expect(page).to have_content("水")
 
       click_link "編集"
       expect(page).to have_content("If-Thenルール編集")
@@ -48,14 +50,15 @@ RSpec.describe "Rule Weekdays", type: :system do
       check "commit_type"
 
       find("summary", text: "曜日の繰り返し設定").click
-      check "火曜日"
-      check "日曜日"
+      find("label", text: "火").click
+      find("label", text: "日").click
 
       click_button "保存する"
 
       expect(page).to have_content("編集しました")
 
-      expect(page).not_to have_content("月・水")
+      expect(page).to have_content("火")
+      expect(page).to have_content("日")
     end
   end
   describe "表示関連" do
@@ -85,13 +88,13 @@ RSpec.describe "Rule Weekdays", type: :system do
       check "commit_type"
 
       find("summary", text: "曜日の繰り返し設定").click
-      check "月曜日"
-      check "火曜日"
-      check "水曜日"
-      check "木曜日"
-      check "金曜日"
-      check "土曜日"
-      check "日曜日"
+      find("label", text: "月").click
+      find("label", text: "火").click
+      find("label", text: "水").click
+      find("label", text: "木").click
+      find("label", text: "金").click
+      find("label", text: "土").click
+      find("label", text: "日").click
 
       click_button "保存する"
 


### PR DESCRIPTION

## 概要
曜日による繰り返しのUIの改善

Close #242 

## 実装内容
### 予定していた作業
- [x]  曜日のフォームを改良
    - [x]  曜日フォームを partial 化
    - [x]  編集時の初期値が入るようにする
    - [x]  「未指定は毎日扱い」テキスト追加
- [x]  曜日のフォームの見た目の調整(tailwind)
    - [x]  checkbox → button風UIにする
    - [x]  選択状態のスタイルを変わるようにする
    - [x]  レイアウト,並びの改善
- [x] 今回の変更に合わせてsystem_specの修正 



### 予定外だが実施した作業
- [x] ifthenruleモデルにあった色に関するメソッドをヘルパーへ変更

## 動作確認
フォームでの表示調整
<img width="374" height="63" alt="image" src="https://github.com/user-attachments/assets/3f1a1f78-3a09-4f4f-9a1f-77cb0b656b5a" />
設定されている曜日のカードでの表示の調整
<img width="207" height="291" alt="image" src="https://github.com/user-attachments/assets/5a9ec9e2-b7f3-4150-8353-79e2a4dd1185" />
