### PR TITLE
Feat/google oauthでのログイン機能追加

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -3,7 +3,7 @@ class OauthsController < ApplicationController
 
   # プロバイダーへの認証リダイレクト
   def oauth
-    #これによりユーザーがgoogleへリダイレクトして本人確認の同意とかをする
+    # これによりユーザーがgoogleへリダイレクトして本人確認の同意とかをする
     login_at(params[:provider])
   end
 

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,0 +1,27 @@
+class OauthsController < ApplicationController
+  skip_before_action :require_login, raise: false
+
+  # プロバイダーへの認証リダイレクト
+  def oauth
+    #これによりユーザーがgoogleへリダイレクトして本人確認の同意とかをする
+    login_at(params[:provider])
+  end
+
+  # OAuth コールバック処理
+  def callback
+    provider = params[:provider]
+    if @user = login_from(provider)
+      redirect_to root_path, notice: "#{provider.titleize}でログインしました！"
+    else
+      begin
+        @user = create_from(provider)
+        reset_session
+        auto_login(@user)
+        redirect_to root_path, notice: "#{provider.titleize}でログインしました！"
+      rescue StandardError => e
+        logger.error "OAuth Error: #{e.message}"
+        redirect_to root_path, alert: "#{provider.titleize}からのログインに失敗しました"
+      end
+    end
+  end
+end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,3 @@
+class Authentication < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :authentications, dependent: :destroy
+  accepts_nested_attributes_for :authentications
+
   has_many :memos, dependent: :destroy
   has_many :if_then_rules, dependent: :destroy
   has_many :reflections, dependent: :destroy
@@ -8,11 +11,11 @@ class User < ApplicationRecord
   validates :password,
             length: { minimum: 3 },
             confirmation: true,
-            if: -> { new_record? || will_save_change_to_crypted_password? }
+            if: -> { (new_record? || will_save_change_to_crypted_password?) && password.present? }
 
   validates :password_confirmation,
             presence: true,
-            if: -> { new_record? || will_save_change_to_crypted_password? }
+            if: -> { (new_record? || will_save_change_to_crypted_password?) && password.present? }
 
   def  all_rules_completed_today?
     today_rules = if_then_rules.active

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -41,7 +41,20 @@
 
     <% end %>
 
-    <%= link_to 'googleでログイン', auth_at_provider_path(provider: "google") %>
+    <%# Googleログインボタン %>
+
+    <%= link_to auth_at_provider_path(provider: :google), class: "btn btn-outline btn-md normal-case font-medium gap-3 border-gray-300 hover:bg-gray-50 hover:border-gray-400" do %>
+      <div class="gsi-material-button-icon">
+        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" xmlns:xlink="http://www.w3.org/1999/xlink" class="w-5 h-5 block">
+          <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+          <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+          <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+          <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+          <path fill="none" d="M0 0h48v48H0z"></path>
+        </svg>
+      </div>
+      <span class="text-gray-700">Googleでログイン</span>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -40,6 +40,8 @@
       </div>
 
     <% end %>
+
+    <%= link_to 'googleでログイン', auth_at_provider_path(provider: "google") %>
   </div>
 </div>
 

--- a/compose.yml
+++ b/compose.yml
@@ -35,6 +35,9 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
       SENTRY_DSN: ${SENTRY_DSN}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      BASE_URL: ${BASE_URL}
     ports:
       - "3000:3000"
     depends_on:

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:remember_me, :external]
+Rails.application.config.sorcery.submodules = [ :remember_me, :external ]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -88,7 +88,7 @@ Rails.application.config.sorcery.configure do |config|
   # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
   # Default: `[]`
   #
-  config.external_providers = [:google]
+  config.external_providers = [ :google ]
 
   # Google OAuth (CLIENT_ID, CLIENT_SECRET は .env から取得)
   # 本番環境では BASE_URL を .env に設定してください（例: https://yourdomain.com）

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [ :remember_me ]
+Rails.application.config.sorcery.submodules = [:remember_me, :external]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -88,7 +88,15 @@ Rails.application.config.sorcery.configure do |config|
   # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
   # Default: `[]`
   #
-  # config.external_providers =
+  config.external_providers = [:google]
+
+  # Google OAuth (CLIENT_ID, CLIENT_SECRET は .env から取得)
+  # 本番環境では BASE_URL を .env に設定してください（例: https://yourdomain.com）
+  config.google.key = ENV.fetch("GOOGLE_CLIENT_ID", "")
+  config.google.secret = ENV.fetch("GOOGLE_CLIENT_SECRET", "")
+  config.google.callback_url = "#{ENV.fetch('BASE_URL', 'http://localhost:3000')}/oauth/callback?provider=google"
+  config.google.user_info_mapping = { email: "email" }
+  config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
 
   # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
   # Path to ca_file. By default use a internal ca-bundle.crt.
@@ -557,7 +565,7 @@ Rails.application.config.sorcery.configure do |config|
     # Class which holds the various external provider data for this user.
     # Default: `nil`
     #
-    # user.authentications_class =
+    user.authentications_class = Authentication
 
     # User's identifier in the `authentications` class.
     # Default: `:user_id`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,11 @@ Rails.application.routes.draw do
   get  "/login",  to: "user_sessions#new"
   post "/login",  to: "user_sessions#create"
   delete "/logout", to: "user_sessions#destroy"
+
+  # OAuth認証 (Google)
+  post "oauth/callback" => "oauths#callback"
+  get "oauth/callback" => "oauths#callback"
+  get "oauth/:provider" => "oauths#oauth", as: :auth_at_provider
   # メモの機能->memos
   resources :memos do
     collection do

--- a/db/migrate/20260307105833_sorcery_external.rb
+++ b/db/migrate/20260307105833_sorcery_external.rb
@@ -1,0 +1,14 @@
+class SorceryExternal < ActiveRecord::Migration[7.2]
+  def change
+    create_table :authentications do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.string :provider, null: false
+      t.string :uid, null: false
+
+      t.timestamps              null: false
+    end
+
+    add_index :authentications, [:provider, :uid], unique: true
+  end
+end

--- a/db/migrate/20260307105833_sorcery_external.rb
+++ b/db/migrate/20260307105833_sorcery_external.rb
@@ -6,9 +6,9 @@ class SorceryExternal < ActiveRecord::Migration[7.2]
       t.string :provider, null: false
       t.string :uid, null: false
 
-      t.timestamps              null: false
+      t.timestamps null: false
     end
 
-    add_index :authentications, [:provider, :uid], unique: true
+    add_index :authentications, [ :provider, :uid ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_28_011923) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_07_105833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "authentications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid", unique: true
+    t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
 
   create_table "if_then_rules", force: :cascade do |t|
     t.text "if_condition"
@@ -60,6 +70,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_28_011923) do
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
   end
 
+  add_foreign_key "authentications", "users"
   add_foreign_key "if_then_rules", "memos", on_delete: :nullify
   add_foreign_key "if_then_rules", "users"
   add_foreign_key "memos", "users"


### PR DESCRIPTION

## 概要
google oauthでのログイン機能追加

Close #181 

## 実装内容
### 予定していた作業
- [x]  google  cloud consoleにてプロジェクトを作成して、client IDとclient secretの入手
- [x]  環境変数としてアプリに導入 compose.yml
- [x] renderでも必要な環境変数を渡す 
- [x]  sorceryで使う新たなテーブル作成 userとのアソシエーション設定
- [x]  sorceryでの:externalサブモジュール導入してgoogleとしての設定追加
- [x]  ユーザーに許可からトークンリクエストまでのリダイレクトのコントローラーやアクション、ルートの作成
- [x]  ログイン画面にリンクの追加


## 動作確認
- [x] 開発環境にてgoogleでのログインでログインできる 
![bcadb339ae7f47ec60d6b7e9f93b64cd](https://github.com/user-attachments/assets/412464aa-7acc-4e6d-a98e-8d19e99b7861)


## 備考
- 本番環境で問題なければgoogle cloud consoleでテストユーザー以外もできるように設定する
- BASE_URLは開発環境では`http://localhost:3000`,本番ではそのアプリのホストhttps://のものにすることでgoogle cloud consoleで設定する許可されたurlを入れることになる。