### PR TITLE
Feat/reflections totaling

### DIFF
--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -35,6 +35,9 @@ class ReflectionsController < ApplicationController
   def index
     authorize Reflection
     @reflections = policy_scope(Reflection).includes(:if_then_rule).order(reflected_on: :desc)
+    @total_reflections_cnt = @reflections.count
+    @today_reflections_cnt = @reflections.where(reflected_on: Date.current).count
+    @week_reflections_cnt = @reflections.where(reflected_on: Time.current.all_week).count
   end
 
   def destroy

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -3,24 +3,36 @@
       今日のルール
     <% end %>
     <!--今日のルール一覧-->
-    <turbo-frame id="today_rules">
-    <%= render "if_then_rules/dash_boards/today_rules", rules: @today_rules %>
-    </turbo-frame>
-    <!-- カードの下の今日やったルールなどの集計表示 -->
-    <turbo-frame id="today_progress">
-    <%= render "if_then_rules/dash_boards/today_progress", progress: today_progress(@today_rules) %>
-    </turbo-frame>
 
-    <div class="mt-12 flex flex-col gap-3">
+<div class="space-y-16">
+    <div class="space-y-12">
+      <div>
+        <turbo-frame id="today_rules">
+        <%= render "if_then_rules/dash_boards/today_rules", rules: @today_rules %>
+        </turbo-frame>
+      </div>
+      <div>
+        <!-- カードの下の今日やったルールなどの集計表示 -->
+        <turbo-frame id="today_progress">
+        <%= render "if_then_rules/dash_boards/today_progress", progress: today_progress(@today_rules) %>
+        </turbo-frame>
+      </div>
+    </div>
+
+
+<!--作成ボタン類-->
+    <div>
+      <div class=" flex flex-col gap-3">
       <%= link_to "新しくマイルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary " %>
-    </div>
-    <div class="mt-4 flex flex-col gap-3">
+      </div>
+      <div class="mt-4 flex flex-col gap-3">
       <%= link_to "新しくメモを作成する",
-          new_memo_path,
-          class: "btn btn-secondary" %>
+      new_memo_path,
+      class: "btn btn-secondary" %>
+      </div>
     </div>
-    
-    <div class="card bg-base-100 shadow p-4 mt-16 ">
+      
+    <div class="card bg-base-100 shadow p-4">
       <p class="text-sm text-gray-500">振り返りタイミング</p>
 
       <div class="flex items-center justify-between mt-1">
@@ -30,7 +42,7 @@
 
         <%= link_to "変更", edit_reflection_time_path, class: "btn btn-sm" %>
       </div>
-</div>
+    </div>
 
 
   <% else %>
@@ -42,7 +54,9 @@
     <div class="mt-12 flex flex-col gap-3">
       <%= link_to "新しくマイルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
     </div>
-  <% end %>
+    <% end %>
+
+</div>
 
 
 

--- a/app/views/if_then_rules/dash_boards/_today_progress.html.erb
+++ b/app/views/if_then_rules/dash_boards/_today_progress.html.erb
@@ -1,8 +1,18 @@
 <turbo-frame id="today_progress">
+<!--progressが持つハッシュからデータを取得する感じ-->
 <div>
-  <div>
-    <%= "今日やったルールの数:#{progress[:done]}" %>
+
+  <%= link_to  reflections_path,data: { turbo_frame: "_top" } do%>
+  <div class="card bg-base-100 shadow">
+    <div class="card-body items-center text-center">
+      <p class="text-sm text-gray-500">今日やったルールの数</p>
+      <p class="text-3xl font-bold">
+        <%= progress[:done] %>
+        <span class="text-sm ">回</span>
+      </p>
+    </div>
   </div>
+  <% end %>
 
   <div class="w-full bg-gray-300 rounded-full h-2 mt-2">
     <div

--- a/app/views/if_then_rules/dash_boards/_today_progress.html.erb
+++ b/app/views/if_then_rules/dash_boards/_today_progress.html.erb
@@ -2,16 +2,8 @@
 <!--progressが持つハッシュからデータを取得する感じ-->
 <div>
 
-  <%= link_to  reflections_path,data: { turbo_frame: "_top" } do%>
-  <div class="card bg-base-100 shadow hover:-translate-y-1">
-    <div class="card-body items-center text-center">
-      <p class="text-sm text-gray-500">今日やったルールの数</p>
-      <p class="text-3xl font-bold">
-        <%= progress[:done] %>
-        <span class="text-sm ">回</span>
-      </p>
-    </div>
-  </div>
+  <%= link_to  reflections_path,data: { turbo_frame: "_top" }, class:"hover:-translate-y-1 block" do%>
+      <%= render "shared/reflection_card", title:"今日やったルールの数",value: progress[:done]  , unit:"回" %>
   <% end %>
 
   <div class="w-full bg-gray-300 rounded-full h-2 mt-2">

--- a/app/views/if_then_rules/dash_boards/_today_progress.html.erb
+++ b/app/views/if_then_rules/dash_boards/_today_progress.html.erb
@@ -3,7 +3,7 @@
 <div>
 
   <%= link_to  reflections_path,data: { turbo_frame: "_top" } do%>
-  <div class="card bg-base-100 shadow">
+  <div class="card bg-base-100 shadow hover:-translate-y-1">
     <div class="card-body items-center text-center">
       <p class="text-sm text-gray-500">今日やったルールの数</p>
       <p class="text-3xl font-bold">

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -45,7 +45,7 @@
 </div>
 
 
-<div class="divider max-w-xl lg:max-w-full mx-auto px-2"></div>
+<div class="divider  mx-auto px-2  text-gray-500">履歴</div>
 <!--日毎にグループ分けされた実行記録-->
   <% if  @reflections.any?%>
     <ul>
@@ -53,8 +53,10 @@
           <h2 class="text-lg font-semibold mt-4 mb-2"><%= date.strftime("%Y年%-m月%-d日") %></h2>
           <ul class="space-y-2">
             <% reflections.each do |reflection| %>
-              <li class="bg-base-100 card shadow-md rounded-lg p-4">
-                <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
+              <li class="bg-base-100 card shadow-md rounded-lg p-4 hover:bg-base-200 ">
+                <%= link_to if_then_rule_path(reflection.if_then_rule) do %>
+                  <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
+                <% end  %>
               </li>
             <% end %>
           </ul>

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -12,36 +12,10 @@
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
   <!--集計のグリッド-->
 
+      <%= render "shared/reflection_card", title:"🔥今日",value: @today_reflections_cnt , unit:"回" %>
+      <%= render "shared/reflection_card", title:"📊合計実行",value: @total_reflections_cnt , unit:"回" %>
+      <%= render "shared/reflection_card", title:"📅今週",value: @week_reflections_cnt  , unit:"回" %>
 
-      <div class="card bg-base-100 shadow">
-        <div class="card-body items-center text-center">
-          <p class="text-sm text-gray-500">🔥今日</p>
-          <p class="text-3xl font-bold">
-            <%= @reflections.where(reflected_on: Date.current).count %>
-            <span class="text-sm ">回</span>
-          </p>
-        </div>
-      </div>
-
-      <div class="card bg-base-100 shadow">
-        <div class="card-body items-center text-center">
-          <p class="text-sm text-gray-500">📊合計実行</p>
-          <p class="text-3xl font-bold">
-            <%= @reflections.count %>
-            <span class="text-sm ">回</span>
-          </p>
-        </div>
-      </div>
-
-      <div class="card bg-base-100 shadow">
-        <div class="card-body items-center text-center">
-          <p class="text-sm text-gray-500">📅今週</p>
-          <p class="text-3xl font-bold">
-            <%= @reflections.where(reflected_on: Time.current.all_week).count %>
-            <span class="text-sm ">回</span>
-          </p>
-        </div>
-      </div>
   <!--集計のグリッドここまで-->
     </div>
   </div>

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -9,7 +9,7 @@
 <!--集計のグリッド-->
     実行記録
   </h2>
-  <div class="grid grid-cols-2 gap-4">
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
 
 
     <div class="card bg-base-100 shadow">
@@ -44,6 +44,8 @@
 
 </div>
 
+
+<div class="divider max-w-xl lg:max-w-full mx-auto px-2"></div>
 <!--日毎にグループ分けされた実行記録-->
   <% if  @reflections.any?%>
     <ul>

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -15,7 +15,7 @@
 
       <div class="card bg-base-100 shadow">
         <div class="card-body items-center text-center">
-          <p class="text-sm text-gray-500">今日</p>
+          <p class="text-sm text-gray-500">🔥今日</p>
           <p class="text-3xl font-bold">
             <%= @reflections.where(reflected_on: Date.current).count %>
             <span class="text-sm ">回</span>
@@ -25,7 +25,7 @@
 
       <div class="card bg-base-100 shadow">
         <div class="card-body items-center text-center">
-          <p class="text-sm text-gray-500">合計実行</p>
+          <p class="text-sm text-gray-500">📊合計実行</p>
           <p class="text-3xl font-bold">
             <%= @reflections.count %>
             <span class="text-sm ">回</span>
@@ -35,7 +35,7 @@
 
       <div class="card bg-base-100 shadow">
         <div class="card-body items-center text-center">
-          <p class="text-sm text-gray-500">今週</p>
+          <p class="text-sm text-gray-500">📅今週</p>
           <p class="text-3xl font-bold">
             <%= @reflections.where(reflected_on: Time.current.all_week).count %>
             <span class="text-sm ">回</span>
@@ -57,7 +57,7 @@
             <div class="divider max-w-xl lg:max-w-full mx-auto px-2  text-gray-500"><%= date.strftime("%Y年%-m月%-d日") %></div>
             <ul class="space-y-2">
               <% reflections.each do |reflection| %>
-                <%= link_to if_then_rule_path(reflection.if_then_rule), class:"bg-base-100 card shadow-md rounded-lg p-4  hover:scale-105" do %>
+                <%= link_to if_then_rule_path(reflection.if_then_rule), class:"bg-base-100 card shadow-md rounded-lg p-4  hover:-translate-y-1" do %>
                   <li>
                     <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
                   </li>

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -57,11 +57,11 @@
             <div class="divider max-w-xl lg:max-w-full mx-auto px-2  text-gray-500"><%= date.strftime("%Y年%-m月%-d日") %></div>
             <ul class="space-y-2">
               <% reflections.each do |reflection| %>
-                <li class="bg-base-100 card shadow-md rounded-lg p-4 hover:bg-base-200 ">
-                  <%= link_to if_then_rule_path(reflection.if_then_rule) do %>
-                      <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
-                  <% end  %>
-                </li>
+                <%= link_to if_then_rule_path(reflection.if_then_rule), class:"bg-base-100 card shadow-md rounded-lg p-4  hover:scale-105" do %>
+                  <li>
+                    <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
+                  </li>
+                <% end  %>
               <% end %>
             </ul>
             <% end %>

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -2,28 +2,74 @@
       振り返り一覧
     <% end %>
 
-<ul>
-<% if  @reflections.any?%>
-  <% @reflections.group_by(&:reflected_on).each do |date, reflections| %>
-    <h2 class="text-lg font-semibold mt-4 mb-2"><%= date.strftime("%Y年%-m月%-d日") %></h2>
-    <ul class="space-y-2">
-      <% reflections.each do |reflection| %>
-        <li class="bg-base-100 card shadow-md rounded-lg p-4">
-          <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
-<% else %>
-    <p class="text-gray-500">
-      まだ振り返りはありません。
-    </p>
-    <p class="text-gray-500">
-    まずは一つメモやルールを作ることから始めましょう。
-    </p>
-    <div class="mt-12 flex flex-col gap-3">
-      <%= link_to "新しくルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
+<div>
+
+
+<h2 class="font-bold text-lg ">
+<!--集計のグリッド-->
+    実行記録
+  </h2>
+  <div class="grid grid-cols-2 gap-4">
+
+
+    <div class="card bg-base-100 shadow">
+      <div class="card-body items-center text-center">
+        <p class="text-sm text-gray-500">今日</p>
+        <p class="text-3xl font-bold">
+          <%= @reflections.where(reflected_on: Date.current).count %>
+          <span class="text-sm ">回</span>
+        </p>
+      </div>
     </div>
-<% end %>
+
+    <div class="card bg-base-100 shadow">
+      <div class="card-body items-center text-center">
+        <p class="text-sm text-gray-500">合計実行</p>
+        <p class="text-3xl font-bold">
+          <%= @reflections.count %>
+          <span class="text-sm ">回</span>
+        </p>
+      </div>
+    </div>
+
+    <div class="card bg-base-100 shadow">
+      <div class="card-body items-center text-center">
+        <p class="text-sm text-gray-500">今週</p>
+        <p class="text-3xl font-bold">
+          <%= @reflections.where(reflected_on: Time.current.all_week).count %>
+          <span class="text-sm ">回</span>
+        </p>
+      </div>
+    </div>
+
+</div>
+
+<!--日毎にグループ分けされた実行記録-->
+  <% if  @reflections.any?%>
+    <ul>
+        <% @reflections.group_by(&:reflected_on).each do |date, reflections| %>
+          <h2 class="text-lg font-semibold mt-4 mb-2"><%= date.strftime("%Y年%-m月%-d日") %></h2>
+          <ul class="space-y-2">
+            <% reflections.each do |reflection| %>
+              <li class="bg-base-100 card shadow-md rounded-lg p-4">
+                <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+    </ul>
+  <% else %>
+      <p class="text-gray-500">
+        まだ振り返りはありません。
+      </p>
+      <p class="text-gray-500">
+      まずは一つメモやルールを作ることから始めましょう。
+      </p>
+      <div class="mt-12 flex flex-col gap-3">
+        <%= link_to "新しくルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
+      </div>
+  <% end %>
+
+</div>
 
 

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -2,78 +2,83 @@
       振り返り一覧
     <% end %>
 
+<div class="space-y-16">
+
+
 <div>
-
-
-<h2 class="font-bold text-lg ">
-<!--集計のグリッド-->
-    実行記録
+  <h2 class="font-bold text-lg ">
+  実行記録
   </h2>
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+  <!--集計のグリッド-->
 
 
-    <div class="card bg-base-100 shadow">
-      <div class="card-body items-center text-center">
-        <p class="text-sm text-gray-500">今日</p>
-        <p class="text-3xl font-bold">
-          <%= @reflections.where(reflected_on: Date.current).count %>
-          <span class="text-sm ">回</span>
-        </p>
+      <div class="card bg-base-100 shadow">
+        <div class="card-body items-center text-center">
+          <p class="text-sm text-gray-500">今日</p>
+          <p class="text-3xl font-bold">
+            <%= @reflections.where(reflected_on: Date.current).count %>
+            <span class="text-sm ">回</span>
+          </p>
+        </div>
       </div>
-    </div>
 
-    <div class="card bg-base-100 shadow">
-      <div class="card-body items-center text-center">
-        <p class="text-sm text-gray-500">合計実行</p>
-        <p class="text-3xl font-bold">
-          <%= @reflections.count %>
-          <span class="text-sm ">回</span>
-        </p>
+      <div class="card bg-base-100 shadow">
+        <div class="card-body items-center text-center">
+          <p class="text-sm text-gray-500">合計実行</p>
+          <p class="text-3xl font-bold">
+            <%= @reflections.count %>
+            <span class="text-sm ">回</span>
+          </p>
+        </div>
       </div>
-    </div>
 
-    <div class="card bg-base-100 shadow">
-      <div class="card-body items-center text-center">
-        <p class="text-sm text-gray-500">今週</p>
-        <p class="text-3xl font-bold">
-          <%= @reflections.where(reflected_on: Time.current.all_week).count %>
-          <span class="text-sm ">回</span>
-        </p>
+      <div class="card bg-base-100 shadow">
+        <div class="card-body items-center text-center">
+          <p class="text-sm text-gray-500">今週</p>
+          <p class="text-3xl font-bold">
+            <%= @reflections.where(reflected_on: Time.current.all_week).count %>
+            <span class="text-sm ">回</span>
+          </p>
+        </div>
       </div>
+  <!--集計のグリッドここまで-->
     </div>
-
-</div>
-
-
-<div class="divider  mx-auto px-2  text-gray-500">履歴</div>
-<!--日毎にグループ分けされた実行記録-->
-  <% if  @reflections.any?%>
-    <ul>
-        <% @reflections.group_by(&:reflected_on).each do |date, reflections| %>
-          <h2 class="text-lg font-semibold mt-4 mb-2"><%= date.strftime("%Y年%-m月%-d日") %></h2>
-          <ul class="space-y-2">
-            <% reflections.each do |reflection| %>
-              <li class="bg-base-100 card shadow-md rounded-lg p-4 hover:bg-base-200 ">
-                <%= link_to if_then_rule_path(reflection.if_then_rule) do %>
-                  <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
-                <% end  %>
-              </li>
+  </div>
+  <div>
+<!--履歴-->
+    <h2 class="font-bold text-lg ">
+      履歴
+    </h2>
+    <!--日毎にグループ分けされた実行記録-->
+    <% if  @reflections.any?%>
+      <ul>
+          <% @reflections.group_by(&:reflected_on).each do |date, reflections| %>
+            <div class="divider max-w-xl lg:max-w-full mx-auto px-2  text-gray-500"><%= date.strftime("%Y年%-m月%-d日") %></div>
+            <ul class="space-y-2">
+              <% reflections.each do |reflection| %>
+                <li class="bg-base-100 card shadow-md rounded-lg p-4 hover:bg-base-200 ">
+                  <%= link_to if_then_rule_path(reflection.if_then_rule) do %>
+                      <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
+                  <% end  %>
+                </li>
+              <% end %>
+            </ul>
             <% end %>
-          </ul>
-        <% end %>
-    </ul>
-  <% else %>
-      <p class="text-gray-500">
-        まだ振り返りはありません。
-      </p>
-      <p class="text-gray-500">
-      まずは一つメモやルールを作ることから始めましょう。
-      </p>
-      <div class="mt-12 flex flex-col gap-3">
-        <%= link_to "新しくルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
-      </div>
-  <% end %>
-
+        </ul>
+      <% else %>
+        <p class="text-gray-500">
+          まだ振り返りはありません。
+        </p>
+        <p class="text-gray-500">
+        まずは一つメモやルールを作ることから始めましょう。
+        </p>
+        <div class="mt-12 flex flex-col gap-3">
+          <%= link_to "新しくルールを作成する", step1_if_then_rules_flow_path, class:"btn btn-primary" %>
+        </div>
+      <% end %>
+  </div>
+  <!--履歴あるいはデータがない場合の文字  ここまで-->
 </div>
 
 

--- a/app/views/shared/_reflection_card.html.erb
+++ b/app/views/shared/_reflection_card.html.erb
@@ -1,0 +1,9 @@
+<div class="card bg-base-100 shadow">
+<div class="card-body items-center text-center">
+  <p class="text-sm text-gray-500"><%= title %></p>
+  <p class="text-3xl font-bold">
+    <%= value %>
+    <span class="text-sm "><%= unit %></span>
+  </p>
+</div>
+</div>


### PR DESCRIPTION

## 概要
アプリの振り返り一覧の内容を充実(振り返り機能の充実)
統計みたいなものを入れて見た目を整えた
Close #172 

## 実装内容
### 予定していた作業
- [x]  一覧の上の方に集計的なカードを作る
    - [x]  合計実施トータル数の追加
    - [x]  今週の実行回数
- [x]  ヘルパーや共通化

- [x]  これまでのルールが日付でグループ化されていたものにそのルール詳細へのリンクを付与する？
- [x]  履歴のUIの整理
- [x]  ダッシュボードでもこの表示を調整。
- [x]  ダッシュボードのレイアウトの調整
    - [x]  振り返りへのリンクを付与?

## 動作確認

<img width="847" height="656" alt="image" src="https://github.com/user-attachments/assets/298cb2ec-6a65-4cf9-95d4-5d7ba9df2d2d" />

<img width="859" height="158" alt="image" src="https://github.com/user-attachments/assets/5e09f1c1-4443-4d1e-aaeb-f3c65463bfff" />


## 備考
- グラフについては不要かも。
- 達成率曜日変更などで変わったりしてくるので全体としてのものは無しにする
- 細かいグラフはルールごとの詳細画面に追加するのはあり。
- 性質上reflectionsはデータが増えやすいのでページネーションを実装するのは早めでもいいかも