### PR TITLE
Fix/rule show enhance

### DIFF
--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -11,6 +11,7 @@ class IfThenRulesController < ApplicationController
 
   def show
     @if_then_rule = policy_scope(IfThenRule).find(params[:id])
+    @rule_cnt = @if_then_rule.reflections.count
     authorize @if_then_rule
   end
 

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -12,7 +12,9 @@ class IfThenRulesController < ApplicationController
   def show
     @if_then_rule = policy_scope(IfThenRule).find(params[:id])
     @rule_cnt = @if_then_rule.reflections.count
+    @memo = @if_then_rule.memo
     authorize @if_then_rule
+    authorize @memo
   end
 
   def new

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -13,7 +13,6 @@ class IfThenRulesController < ApplicationController
     @if_then_rule = policy_scope(IfThenRule).find(params[:id])
     @rule_cnt = @if_then_rule.reflections.count
     @memo = @if_then_rule.memo
-    @last_reflection_date = @if_then_rule.reflections.maximum(:reflected_on)
     authorize @if_then_rule
     authorize @memo
   end

--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -13,6 +13,7 @@ class IfThenRulesController < ApplicationController
     @if_then_rule = policy_scope(IfThenRule).find(params[:id])
     @rule_cnt = @if_then_rule.reflections.count
     @memo = @if_then_rule.memo
+    @last_reflection_date = @if_then_rule.reflections.maximum(:reflected_on)
     authorize @if_then_rule
     authorize @memo
   end

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -41,7 +41,7 @@ module IfThenRulesHelper
     end
   end
 
-# そのルールの設定曜日に基づいた次回曜日のヘルパー
+    # そのルールの設定曜日に基づいた次回曜日のヘルパー
     def next_schedule_label(rule)
       next_schedule = rule.next_schedule
       date = next_schedule[:date]
@@ -57,6 +57,5 @@ module IfThenRulesHelper
       return "明日" if next_schedule[:label] == :tomorrow
       # それ以降はその日付を返す
       I18n.l(date, format: :short)
-
     end
 end

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -43,16 +43,20 @@ module IfThenRulesHelper
 
 # そのルールの設定曜日に基づいた次回曜日のヘルパー
     def next_schedule_label(rule)
-      date = rule.next_scheduled_date
-      return "ステータスが実行中ではありません" unless rule.status == "active"
-      return "予定なし" unless date #何かしらの理由でnext_scheduled_dateがnilになる場合
+      next_schedule = rule.next_schedule
+      date = next_schedule[:date]
+      return "ステータスが実行中ではありません" if next_schedule[:label] == :not_active
+      return "予定なし" if next_schedule[:label] == :no_schedule
 
       today = Date.current
 
-      return "今日" if date == today
-      return "明日" if date == today + 1
+      return "毎日(実行済み)" if next_schedule[:label] == :everyday_reflected
+      return "毎日" if next_schedule[:label] == :everyday
+      return "今日(実行済み)" if next_schedule[:label] == :today_reflected
+      return "今日" if next_schedule[:label] == :today
+      return "明日" if next_schedule[:label] == :tomorrow
       # それ以降はその日付を返す
       I18n.l(date, format: :short)
 
-  end
+    end
 end

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -58,4 +58,10 @@ module IfThenRulesHelper
       # それ以降はその日付を返す
       I18n.l(date, format: :short)
     end
+
+    def last_reflected_day(rule)
+      last_day = rule.last_reflected_day
+      return "まだ実行記録がありません" if last_day == nil
+      I18n.l(last_day, format: :short)
+    end
 end

--- a/app/helpers/if_then_rules_helper.rb
+++ b/app/helpers/if_then_rules_helper.rb
@@ -40,4 +40,19 @@ module IfThenRulesHelper
     when "habituated" then "has-[:checked]:bg-slate-900 has-[:checked]:outline-slate-900 has-[:checked]:font-semibold  has-[:checked]:text-white"
     end
   end
+
+# そのルールの設定曜日に基づいた次回曜日のヘルパー
+    def next_schedule_label(rule)
+      date = rule.next_scheduled_date
+      return "ステータスが実行中ではありません" unless rule.status == "active"
+      return "予定なし" unless date #何かしらの理由でnext_scheduled_dateがnilになる場合
+
+      today = Date.current
+
+      return "今日" if date == today
+      return "明日" if date == today + 1
+      # それ以降はその日付を返す
+      I18n.l(date, format: :short)
+
+  end
 end

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -50,4 +50,16 @@ class IfThenRule < ApplicationRecord
     when "habituated" then "定着済み"
     end
   end
+
+  def next_scheduled_date
+    today = Date.current
+    wdays = weekdays # [1,3,5] などの曜日データ
+    return Date.tomorrow if wdays==[] #正規化により空配列が毎日なので次回の実行日は明日
+    0.upto(7) do |i|
+      date = today + i #今日を基準として１日づつ増やして、データの曜日との一致を検証する
+      return date if wdays.include?(date.wday) # 曜日の数字で検証して、一致したらその日を返す
+    end
+
+    nil
+  end
 end

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -24,6 +24,10 @@ class IfThenRule < ApplicationRecord
     @today_reflection ||= reflections.today.first
   end
 
+  def last_reflected_day
+    reflections.maximum(:reflected_on)
+  end
+
 
   # 引数の曜日が設定された曜日にあるのか？
   def scheduled_for?(date)

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -53,17 +53,17 @@ class IfThenRule < ApplicationRecord
   def next_schedule
     date = next_scheduled_date
 
-    return {date: date, label: :not_active} unless active?
-    return {date: date, label: :no_schedule} unless date #何かしらの理由でnext_scheduled_dateがnilになる場合
+    return { date: date, label: :not_active } unless active?
+    return { date: date, label: :no_schedule } unless date # 何かしらの理由でnext_scheduled_dateがnilになる場合
 
     today = Date.current
     return { label: :everyday_reflected } if weekdays.empty? && reflected_today?
     return { label: :everyday } if weekdays.empty?
-    return {date: date, label: :today_reflected} if date == today && reflected_today?
-    return {date: date, label: :today} if date == today
-    return {date: date, label: :tomorrow} if date == today + 1
+    return { date: date, label: :today_reflected } if date == today && reflected_today?
+    return { date: date, label: :today } if date == today
+    return { date: date, label: :tomorrow } if date == today + 1
     # それ以降
-    {date: date, label: :later}
+    { date: date, label: :later }
   end
 
 private
@@ -71,9 +71,9 @@ private
   def next_scheduled_date
     today = Date.current
     wdays = weekdays # [1,3,5] などの曜日データ
-    return today if wdays.empty? #正規化により空配列が毎日なので一応todayを返す
+    return today if wdays.empty? # 正規化により空配列が毎日なので一応todayを返す
     0.upto(7) do |i|
-      date = today + i #今日を基準として１日づつ増やして、データの曜日との一致を検証する
+      date = today + i # 今日を基準として１日づつ増やして、データの曜日との一致を検証する
       return date if wdays.include?(date.wday) # 曜日の数字で検証して、一致したらその日を返す
     end
 

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -17,11 +17,11 @@ class IfThenRule < ApplicationRecord
   end
 
   def reflected_today?
-  reflections.any? { |r| r.reflected_on == Date.current }
+    @reflected_today ||= reflections.any? { |r| r.reflected_on == Date.current }
   end
 
   def today_reflection
-    reflections.find_by(reflected_on: Date.current)
+    @today_feflection ||= reflections.find_by(reflected_on: Date.current)
   end
 
 
@@ -50,11 +50,28 @@ class IfThenRule < ApplicationRecord
     when "habituated" then "定着済み"
     end
   end
+  def next_schedule
+    date = next_scheduled_date
+
+    return {date: date, label: :not_active} unless active?
+    return {date: date, label: :no_schedule} unless date #何かしらの理由でnext_scheduled_dateがnilになる場合
+
+    today = Date.current
+    return { label: :everyday_reflected } if weekdays.empty? && reflected_today?
+    return { label: :everyday } if weekdays.empty?
+    return {date: date, label: :today_reflected} if date == today && reflected_today?
+    return {date: date, label: :today} if date == today
+    return {date: date, label: :tomorrow} if date == today + 1
+    # それ以降
+    {date: date, label: :later}
+  end
+
+private
 
   def next_scheduled_date
     today = Date.current
     wdays = weekdays # [1,3,5] などの曜日データ
-    return Date.tomorrow if wdays==[] #正規化により空配列が毎日なので次回の実行日は明日
+    return today if wdays.empty? #正規化により空配列が毎日なので一応todayを返す
     0.upto(7) do |i|
       date = today + i #今日を基準として１日づつ増やして、データの曜日との一致を検証する
       return date if wdays.include?(date.wday) # 曜日の数字で検証して、一致したらその日を返す

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -17,11 +17,11 @@ class IfThenRule < ApplicationRecord
   end
 
   def reflected_today?
-    @reflected_today ||= reflections.any? { |r| r.reflected_on == Date.current }
+    @reflected_today ||= reflections.today.any?
   end
 
   def today_reflection
-    @today_feflection ||= reflections.find_by(reflected_on: Date.current)
+    @today_reflection ||= reflections.today.first
   end
 
 

--- a/app/models/reflection.rb
+++ b/app/models/reflection.rb
@@ -3,4 +3,5 @@ class Reflection < ApplicationRecord
   belongs_to :if_then_rule
 
   validates :reflected_on, presence: true
+  scope :today, -> { where(reflected_on: Date.current) }
 end

--- a/app/views/if_then_rules/cards/_rule_actions_show.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_show.html.erb
@@ -1,21 +1,4 @@
 <div>
-      <!--ルールの元になったメモ-->
-    <div>
-      <% if rule.memo.present? %>
-      <div  class="bg-memo card rounded-lg shadow-sm">
-        <p class="text-[11px] text-gray-400 mt-1">
-          <%= rule.memo.title.presence || "（無題）" %>
-        </p>
-        <p class="text-[11px] text-gray-400 mt-1">
-          <%= rule.memo.body || "" %>
-        </p>
-      </div>
-      <% else %>
-        <p class="text-[11px] text-gray-400 mt-1">
-          元のメモがありません
-        </p>
-      <% end %>
-    </div>
       <!--ボタン集-->
       <div class="card-actions justify-end mt-4">
         <%= link_to "編集",

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -7,16 +7,7 @@
       </p>
     <% end %>
 
-  <!--ルールのifとthenのグループ-->
-  <%= link_to if_then_rule_path(rule),
-  class:"cursor-pointer hover:bg-base-200 transition group",
-  data:{turbo_frame: "_top"} do %>
-    <div class = "  p-4 rounded-t-lg ">
-    <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
-    </div>
-  <% end %>
-
-    <!--ルールのUI関係のグループ ブロックをわたす。-->
+    <!--ルールそのものやUI関係のグループ それぞれの場所でルールsentenceなどのブロックをわたす。-->
 
     <%= yield %>
     <%= render "if_then_rules/cards/rule_weekdays", weekdays: rule.weekdays %>

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -8,11 +8,9 @@
     <% end %>
 
   <!--ルールのifとthenのグループ-->
-  <%= link_to if_then_rule_path(rule), class:"font-semibold
-  cursor-pointer
-  hover:underline
-  hover:text-primary
-  transition", data:{turbo_frame: "_top"} do%>
+  <%= link_to if_then_rule_path(rule),
+  class:"cursor-pointer hover:bg-base-200 transition",
+  data:{turbo_frame: "_top"} do %>
     <div class = "  p-4 rounded-t-lg ">
     <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
     </div>

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -8,12 +8,18 @@
     <% end %>
 
   <!--ルールのifとthenのグループ-->
-  <div class = "  p-4 rounded-t-lg ">
+  <%= link_to if_then_rule_path(rule), class:"font-semibold
+  cursor-pointer
+  hover:underline
+  hover:text-primary
+  transition", data:{turbo_frame: "_top"} do%>
+    <div class = "  p-4 rounded-t-lg ">
     <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
     </div>
-    
+  <% end %>
+
     <!--ルールのUI関係のグループ ブロックをわたす。-->
-    
+
     <%= yield %>
     <%= render "if_then_rules/cards/rule_weekdays", weekdays: rule.weekdays %>
 

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -9,7 +9,7 @@
 
   <!--ルールのifとthenのグループ-->
   <%= link_to if_then_rule_path(rule),
-  class:"cursor-pointer hover:bg-base-200 transition",
+  class:"cursor-pointer hover:bg-base-200 transition group",
   data:{turbo_frame: "_top"} do %>
     <div class = "  p-4 rounded-t-lg ">
     <%= render "if_then_rules/cards/rule_sentence", rule: rule %>

--- a/app/views/if_then_rules/cards/_rule_sentence.html.erb
+++ b/app/views/if_then_rules/cards/_rule_sentence.html.erb
@@ -1,13 +1,13 @@
-<p class="text-xs font-medium text-secondary text-left">
+<p class="text-xs font-medium text-secondary text-left group-hover:bg-base-200">
   もし
 </p>
-<p class="text-md bg-blue-100 rounded px-2 py-1 text-primary">
+<p class="text-md bg-blue-100 rounded px-2 py-1 text-primary group-hover:bg-base-200">
   <%= rule.if_condition %>
 </p>
 
-<p class="text-xs font-medium text-secondary text-left">
+<p class="text-xs font-medium text-secondary text-left group-hover:bg-base-200">
   その時は
 </p>
-<p class="text-lg font-semibold text-primary bg-green-100 rounded px-2 py-1">
+<p class="text-lg font-semibold text-primary bg-green-100 rounded px-2 py-1 group-hover:bg-base-200">
   <%= rule.then_action %>
 </p>

--- a/app/views/if_then_rules/dash_boards/_today_rules.html.erb
+++ b/app/views/if_then_rules/dash_boards/_today_rules.html.erb
@@ -5,6 +5,14 @@
 
     <!--card-->
       <%= render "if_then_rules/cards/rule_card",  rule: rule,bg_class: rule.reflected_today? ? "bg-base-300 " : "bg-base-100" , show_status: false do %>
+          <!--ルールのifとthenのグループ-->
+        <%= link_to if_then_rule_path(rule),
+        class:"cursor-pointer hover:bg-base-200 transition group",
+        data:{turbo_frame: "_top"} do %>
+          <div class = "  p-4 rounded-t-lg ">
+          <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
+          </div>
+        <% end %>
         <%= render "if_then_rules/cards/rule_actions_dashboard",  rule: rule %>
       <% end %>
 

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -37,6 +37,14 @@
     <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <% @searched_rules.each do |rule| %>
         <%= render "if_then_rules/cards/rule_card",  rule: rule, bg_class: "bg-base-100" do %>
+          <!--ルールのifとthenのグループ-->
+          <%= link_to if_then_rule_path(rule),
+          class:"cursor-pointer hover:bg-base-200 transition group",
+          data:{turbo_frame: "_top"} do %>
+            <div class = "  p-4 rounded-t-lg ">
+            <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
+            </div>
+          <% end %>
           <%= render "if_then_rules/cards/rule_actions_index",  rule: rule %>
         <% end %>
       <% end %>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -19,7 +19,8 @@
   <!--集計のグリッド-->
 
       <%= render "shared/reflection_card", title:"📊合計実行",value: @rule_cnt , unit:"回" %>
-      <%= render "shared/reflection_card", title:"📊最後の実行日",value: @last_reflection_date , unit:"" %>
+      <%= render "shared/reflection_card", title:"📆最後の実行日",value: I18n.l(@last_reflection_date, format: :short) , unit:"" %>
+      <%= render "shared/reflection_card", title:"📆次回実行日",value: next_schedule_label(@if_then_rule) , unit:"" %>
 
 
   <!--集計のグリッドここまで-->

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -1,7 +1,7 @@
     <% content_for :title do %>
       If-Thenルール詳細
     <% end %>
-<div>
+<div class="space-y-12">
 <!--ルールの表示-->
   <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100" do %>
       <!--ルールのifとthenのグループ-->
@@ -29,7 +29,30 @@
 
 
 
-
+  <!--ルールの元になったメモ-->
+  <div>
+    <h2 class="font-bold text-lg ">
+    元になったメモ
+    </h2>
+    <% if @memo.present? %>
+      <%= link_to memo_path(@memo),
+          class:"cursor-pointer hover:bg-base-200 transition group",
+          data:{turbo_frame: "_top"} do %>
+        <div  class="bg-memo card rounded-lg shadow-sm group-hover:bg-base-200">
+          <p class="text-[11px] text-gray-400 mt-1">
+            <%= @memo.title.presence || "（無題）" %>
+          </p>
+          <p class="text-[11px] text-gray-400 mt-1">
+            <%= @memo.body || "" %>
+          </p>
+        </div>
+      <% end %>
+    <% else %>
+      <p class="text-[11px] text-gray-400 mt-1">
+        元のメモがありません
+      </p>
+    <% end %>
+  </div>
 
 
 </div>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -40,7 +40,7 @@
       <%= link_to memo_path(@memo),
           class:"cursor-pointer hover:bg-base-200 transition group",
           data:{turbo_frame: "_top"} do %>
-        <div  class="bg-memo card rounded-lg shadow-sm group-hover:bg-base-200">
+        <div  class="bg-memo card rounded-lg shadow-sm group-hover:bg-base-200 min-h-32">
           <p class="text-[11px] text-gray-400 mt-1">
             <%= @memo.title.presence || "（無題）" %>
           </p>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -1,12 +1,35 @@
     <% content_for :title do %>
       If-Thenルール詳細
     <% end %>
+<div>
+<!--ルールの表示-->
+  <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100" do %>
+      <!--ルールのifとthenのグループ-->
+      <div class = "  p-4 rounded-t-lg ">
+      <%= render "if_then_rules/cards/rule_sentence", rule: @if_then_rule %>
+      </div>
+    <%= render "if_then_rules/cards/rule_actions_show",  rule: @if_then_rule %>
+  <% end %>
+
+  <div>
+    <h2 class="font-bold text-lg ">
+    実行記録
+    </h2>
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+  <!--集計のグリッド-->
+
+      <%= render "shared/reflection_card", title:"📊合計実行",value: @rule_cnt , unit:"回" %>
 
 
-        <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100" do %>
-            <!--ルールのifとthenのグループ-->
-            <div class = "  p-4 rounded-t-lg ">
-            <%= render "if_then_rules/cards/rule_sentence", rule: @if_then_rule %>
-            </div>
-          <%= render "if_then_rules/cards/rule_actions_show",  rule: @if_then_rule %>
-        <% end %>
+  <!--集計のグリッドここまで-->
+    </div>
+  </div>
+
+
+
+
+
+
+
+
+</div>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -19,7 +19,7 @@
   <!--集計のグリッド-->
 
       <%= render "shared/reflection_card", title:"📊合計実行",value: @rule_cnt , unit:"回" %>
-      <%= render "shared/reflection_card", title:"📆最後の実行日",value: I18n.l(@last_reflection_date, format: :short) , unit:"" %>
+      <%= render "shared/reflection_card", title:"📆最後の実行日",value: last_reflected_day(@if_then_rule) , unit:"" %>
       <%= render "shared/reflection_card", title:"📆次回実行日",value: next_schedule_label(@if_then_rule) , unit:"" %>
 
 

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -4,5 +4,9 @@
 
 
         <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100" do %>
+            <!--ルールのifとthenのグループ-->
+            <div class = "  p-4 rounded-t-lg ">
+            <%= render "if_then_rules/cards/rule_sentence", rule: @if_then_rule %>
+            </div>
           <%= render "if_then_rules/cards/rule_actions_show",  rule: @if_then_rule %>
         <% end %>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -19,6 +19,7 @@
   <!--集計のグリッド-->
 
       <%= render "shared/reflection_card", title:"📊合計実行",value: @rule_cnt , unit:"回" %>
+      <%= render "shared/reflection_card", title:"📊最後の実行日",value: @last_reflection_date , unit:"" %>
 
 
   <!--集計のグリッドここまで-->


### PR DESCRIPTION

## 概要
ルールの詳細画面を充実させる

Close #252 

## 実装内容
### 予定していた作業

- [x]  一覧から詳細へのリンクをボタンでなくカード全体(だけでなくルールのタイトルにも入れる)にする？
    - [x]  編集や削除のボタンの押し間違い対策はする
    - [x]  ダッシュボードでも追加？
- [x]  記録関係
    - [x]  そのルールの合計実施トータル数
    
- [x]  日付関係
    - [x]  最後の実行日
    - [x]  次の実行予定(明日とか曜日とか)

- [x]  レイアウトの調整
- [x]  メモをクリックするとそのメモの詳細に



### 予定外だが実施した作業
- [x] リファクタリング

## 動作確認
<img width="702" height="796" alt="image" src="https://github.com/user-attachments/assets/a64e8832-f95d-4929-b81d-aa78944b4f86" />



## 備考
やるにしても別のイシューにする
- [ ]  今週の実行回数あるいはヒートマップ
- [ ]  曜日を月曜開始にする？
- [ ]  編集のショートカット的にステータスだけ簡単に変えられるようにしてもいいかも？
→定着済みにするボタンみたいな
これをするとなるとturboを使用することになりそうなので別イシュー

