### PR TITLE
Fix/memo show enhance

### DIFF
--- a/app/controllers/if_then_rules_controller.rb
+++ b/app/controllers/if_then_rules_controller.rb
@@ -14,7 +14,6 @@ class IfThenRulesController < ApplicationController
     @rule_cnt = @if_then_rule.reflections.count
     @memo = @if_then_rule.memo
     authorize @if_then_rule
-    authorize @memo
   end
 
   def new

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -31,7 +31,7 @@ class MemosController < ApplicationController
   end
 
   def show
-    @memo = policy_scope(Memo).find(params[:id])
+    @memo = policy_scope(Memo).includes(:if_then_rules).find(params[:id])
     authorize @memo
     @from_rule_flow = params[:from] == "rule_flow"
   end

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -31,7 +31,7 @@ class MemosController < ApplicationController
   end
 
   def show
-    @memo = policy_scope(Memo).includes(:if_then_rules).find(params[:id])
+    @memo = policy_scope(Memo).find(params[:id])
     authorize @memo
     @from_rule_flow = params[:from] == "rule_flow"
   end

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -23,7 +23,11 @@ class MemosController < ApplicationController
     @memo = current_user.memos.build(memo_params)
     @from_rule_flow = params[:memo][:from] == "rule_flow"
     if @memo.save
+      if @from_rule_flow
       redirect_to memo_path(@memo, from: "rule_flow"), notice: "メモの作成が成功しました"
+      else
+      redirect_to memo_path(@memo), notice: "メモの作成が成功しました"
+      end
     else
       flash.now[:alert] = "メモの作成が失敗しました"
       render :new, status: :unprocessable_content

--- a/app/views/if_then_rules/cards/_rule_actions_dashboard.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_dashboard.html.erb
@@ -1,19 +1,17 @@
 <div>
-
-
   <div class="px-4 pb-4 space-y-2">
     <% if rule.reflected_today? %>
       <p class="text-gray-700">完了済み！</p>
       <%= button_to "取り消す",
         if_then_rule_reflection_path(rule,rule.today_reflection.id),
         method: :delete,
-        class: "btn btn-xs btn-ghost"
+        class: "btn btn-xs btn-ghost z-10 relative"
       %>
     <% else %>
       <%= button_to "実行済み！",
         if_then_rule_reflections_path(rule),
         method: :post,
-        class: "btn btn-lg btn-success shadow-sm"
+        class: "btn btn-lg btn-success shadow-sm z-10 relative"
       %>
     <% end %>
   </div>
@@ -21,10 +19,8 @@
     <div class="flex justify-end ">
     <%= link_to "編集",
       edit_if_then_rule_path(rule),
-      class: "btn btn-ghost btn-sm text-xs",
+      class: "btn btn-ghost btn-sm text-xs z-10",
       data: { turbo_frame: "_top" }
     %>
   </div>
-
-
 </div>

--- a/app/views/if_then_rules/cards/_rule_actions_index.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_index.html.erb
@@ -13,9 +13,7 @@
     </div>
       <!--ボタン集-->
       <div class="card-actions justify-end mt-4">
-        <%= link_to "詳細",
-                    if_then_rule_path(rule),
-                    class: "btn btn-ghost btn-sm z-10" %>
+
         <%= link_to "編集",
                     edit_if_then_rule_path(rule),
                     class: "btn btn-ghost btn-sm btn-primary z-10" %>

--- a/app/views/if_then_rules/cards/_rule_actions_index.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_index.html.erb
@@ -15,16 +15,16 @@
       <div class="card-actions justify-end mt-4">
         <%= link_to "詳細",
                     if_then_rule_path(rule),
-                    class: "btn btn-ghost btn-sm " %>
+                    class: "btn btn-ghost btn-sm z-10" %>
         <%= link_to "編集",
                     edit_if_then_rule_path(rule),
-                    class: "btn btn-ghost btn-sm btn-primary" %>
+                    class: "btn btn-ghost btn-sm btn-primary z-10" %>
         <%= link_to "削除",
           if_then_rule_path(rule),
           data: {
                       turbo_method: :delete,
                       turbo_confirm: "このルールを削除しますか？" },
-            class: "btn btn-ghost btn-error btn-sm"
+            class: "btn btn-ghost btn-error btn-sm z-10"
         %>
       </div>
 </div>

--- a/app/views/if_then_rules/cards/_rule_actions_show.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_show.html.erb
@@ -3,13 +3,13 @@
       <div class="card-actions justify-end mt-4">
         <%= link_to "編集",
                     edit_if_then_rule_path(rule),
-                    class: "btn btn-ghost btn-sm btn-primary" %>
+                    class: "btn btn-ghost btn-sm btn-primary z-10" %>
         <%= link_to "削除",
           if_then_rule_path(rule),
           data: {
                       turbo_method: :delete,
                       turbo_confirm: "このルールを削除しますか？" },
-            class: "btn btn-ghost btn-error btn-sm"
+            class: "btn btn-ghost btn-error btn-sm z-10"
         %>
       </div>
 </div>

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -1,5 +1,7 @@
 
-<div class=" <%= bg_class %>  card shadow-md rounded-lg  space-y-2 grid grid-rows-[1fr_0.6fr] relative <%= " hover:-translate-y-1 " if local_assigns.fetch(:absolute_link, nil) %>">
+<div class=" <%= bg_class %>  card shadow-md rounded-lg  space-y-2 relative
+  <%= " grid grid-rows-[1fr_0.6fr] " if local_assigns.fetch(:card_actions, false) %>
+  <%= " hover:-translate-y-1 " if local_assigns.fetch(:absolute_link, nil) %>">
 
 
     <!-- absolute_linkを入れることでカードの全体を覆う透明なリンクを追加する -->

--- a/app/views/if_then_rules/cards/_rule_card.html.erb
+++ b/app/views/if_then_rules/cards/_rule_card.html.erb
@@ -1,5 +1,17 @@
 
-<div class=" <%= bg_class %>  card shadow-md rounded-lg  space-y-2 grid grid-rows-[1fr_0.6fr] relative">
+<div class=" <%= bg_class %>  card shadow-md rounded-lg  space-y-2 grid grid-rows-[1fr_0.6fr] relative <%= " hover:-translate-y-1 " if local_assigns.fetch(:absolute_link, nil) %>">
+
+
+    <!-- absolute_linkを入れることでカードの全体を覆う透明なリンクを追加する -->
+    <!-- 他のuiで押したいボタンなどはz-10などにより手前に持ってくること。-->
+    <% if local_assigns.fetch(:absolute_link, nil) %>
+        <%= link_to absolute_link,
+          class:"cursor-pointer transition group absolute inset-0",
+          data:{turbo_frame: "_top"} do end%>
+    <% end %>
+
+
+
     <!--ルールのステータス(表示したくない時はローカル引数show_statusをfalseへ)-->
     <% if local_assigns.fetch(:show_status, true) %>
       <p class="tag <%= status_color_class(rule.status) %>text-white inline-block  px-2.5 py-0.5 text-[10px] absolute top-2 right-2 rounded-lg opacity-80">
@@ -7,10 +19,23 @@
       </p>
     <% end %>
 
-    <!--ルールそのものやUI関係のグループ それぞれの場所でルールsentenceなどのブロックをわたす。-->
+    <!--ルールそのものやUI関係のグループ。-->
+    <div class = "  p-4 rounded-t-lg ">
+      <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
+    </div>
 
-    <%= yield %>
+
+    <% if local_assigns.fetch(:card_actions, false) == :index%>
+      <%= render "if_then_rules/cards/rule_actions_index",  rule: rule %>
+    <% elsif local_assigns.fetch(:card_actions, false) == :dash_board%>
+      <%= render "if_then_rules/cards/rule_actions_dashboard",  rule: rule %>
+    <% elsif local_assigns.fetch(:card_actions, false) == :show%>
+      <%= render "if_then_rules/cards/rule_actions_show",  rule: @if_then_rule %>
+    <% end %>
+
+<!--ルールの繰り返し曜日(表示したくない時はローカル引数show_weeksをfalseへ)-->
+  <% if local_assigns.fetch(:show_weeks, false) %>
     <%= render "if_then_rules/cards/rule_weekdays", weekdays: rule.weekdays %>
-
+  <% end %>
 
 </div>

--- a/app/views/if_then_rules/dash_boards/_today_rules.html.erb
+++ b/app/views/if_then_rules/dash_boards/_today_rules.html.erb
@@ -4,17 +4,7 @@
     <% rules.each do |rule| %>
 
     <!--card-->
-      <%= render "if_then_rules/cards/rule_card",  rule: rule,bg_class: rule.reflected_today? ? "bg-base-300 " : "bg-base-100" , show_status: false do %>
-          <!--ルールのifとthenのグループ-->
-        <%= link_to if_then_rule_path(rule),
-        class:"cursor-pointer hover:bg-base-200 transition group",
-        data:{turbo_frame: "_top"} do %>
-          <div class = "  p-4 rounded-t-lg ">
-          <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
-          </div>
-        <% end %>
-        <%= render "if_then_rules/cards/rule_actions_dashboard",  rule: rule %>
-      <% end %>
+      <%= render "if_then_rules/cards/rule_card",  rule: rule, bg_class: rule.reflected_today? ? "bg-base-300 " : "bg-base-100" , show_status: false, absolute_link: if_then_rule_path(rule), show_weeks: true ,card_actions: :dash_board%>
 
     <% end %>
   </div>

--- a/app/views/if_then_rules/edit.html.erb
+++ b/app/views/if_then_rules/edit.html.erb
@@ -2,4 +2,9 @@
     <% content_for :title do %>
       If-Thenルール編集
     <% end %>
+    <div class="relative">
+    <%= link_to '← ルール詳細へ戻る',
+        if_then_rule_path(@if_then_rule),
+        class: 'btn btn-ghost btn-sm ' %>
+    </div>
 <%= render "form", if_then_rule_form: @if_then_rule_form, url:if_then_rule_path(@if_then_rule), method: :patch %>

--- a/app/views/if_then_rules/index.html.erb
+++ b/app/views/if_then_rules/index.html.erb
@@ -36,17 +36,8 @@
   <% if @searched_rules.any? %>
     <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <% @searched_rules.each do |rule| %>
-        <%= render "if_then_rules/cards/rule_card",  rule: rule, bg_class: "bg-base-100" do %>
-          <!--ルールのifとthenのグループ-->
-          <%= link_to if_then_rule_path(rule),
-          class:"cursor-pointer hover:bg-base-200 transition group",
-          data:{turbo_frame: "_top"} do %>
-            <div class = "  p-4 rounded-t-lg ">
-            <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
-            </div>
-          <% end %>
-          <%= render "if_then_rules/cards/rule_actions_index",  rule: rule %>
-        <% end %>
+        <%= render "if_then_rules/cards/rule_card",  rule: rule, bg_class: "bg-base-100",absolute_link: if_then_rule_path(rule), show_weeks: true, card_actions: :index %>
+
       <% end %>
     </div>
   <% elsif @if_then_rules.any? %>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -9,7 +9,7 @@
     </div>
 <div class="space-y-12">
 <!--ルールの表示-->
-  <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100", card_actions: :show  %>
+  <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100", card_actions: :show, show_weeks: true  %>
 
   <div>
     <h2 class="font-bold text-lg ">
@@ -26,10 +26,6 @@
   <!--集計のグリッドここまで-->
     </div>
   </div>
-
-
-
-
 
   <!--ルールの元になったメモ-->
   <div>

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -9,13 +9,7 @@
     </div>
 <div class="space-y-12">
 <!--ルールの表示-->
-  <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100" do %>
-      <!--ルールのifとthenのグループ-->
-      <div class = "  p-4 rounded-t-lg ">
-      <%= render "if_then_rules/cards/rule_sentence", rule: @if_then_rule %>
-      </div>
-    <%= render "if_then_rules/cards/rule_actions_show",  rule: @if_then_rule %>
-  <% end %>
+  <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100", card_actions: :show  %>
 
   <div>
     <h2 class="font-bold text-lg ">

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -1,6 +1,12 @@
     <% content_for :title do %>
       If-Thenルール詳細
     <% end %>
+
+    <div class="relative">
+    <%= link_to '← ルール一覧へ戻る',
+        if_then_rules_path,
+        class: 'btn btn-ghost btn-sm ' %>
+    </div>
 <div class="space-y-12">
 <!--ルールの表示-->
   <%= render "if_then_rules/cards/rule_card",  rule: @if_then_rule, bg_class: "bg-base-100" do %>
@@ -38,9 +44,9 @@
     </h2>
     <% if @memo.present? %>
       <%= link_to memo_path(@memo),
-          class:"cursor-pointer hover:bg-base-200 transition group",
+          class:"cursor-pointer hover:-translate-y-1 transition group",
           data:{turbo_frame: "_top"} do %>
-        <div  class="bg-memo card rounded-lg shadow-sm group-hover:bg-base-200 min-h-32">
+        <div  class="bg-memo card rounded-lg shadow-sm hover:-translate-y-1 min-h-32">
           <p class="text-[11px] text-gray-400 mt-1">
             <%= @memo.title.presence || "（無題）" %>
           </p>

--- a/app/views/memos/_memo_card.html.erb
+++ b/app/views/memos/_memo_card.html.erb
@@ -1,0 +1,44 @@
+<div class="bg-memo card shadow-md rounded-lg p-4 relative <%= "hover:-translate-y-1" if local_assigns[:show_link] %>">
+        <% if local_assigns[:show_link] %>
+          <%= link_to memo_path(memo),
+          class:"cursor-pointer group absolute inset-0",
+          data:{turbo_frame: "_top"} do end%>
+        <% end %>
+            <!--メモの内容の領域-->
+            <div>
+              <h2 class="card-title">
+              <!--無題に対応している-->
+                <%= memo.display_title %>
+              </h2>
+
+              <div class="card-body">
+                <% if memo.body.present? %>
+                  <p class="text-sm text-base-content/80 line-clamp-3">
+                    <%= memo.body %>
+                  </p>
+                <% else %>
+                  <p class="text-sm text-base-content/50 italic">
+                    本文はありません
+                  </p>
+                <% end %>
+              </div>
+            </div>
+
+            <!--メモのボタン等の領域-->
+            <div class="card-actions justify-end mt-4 ">
+              <%= link_to "詳細",
+                    memo_path(memo),
+                    class: "btn btn-sm btn-ghost z-10" %>
+
+              <%= link_to "編集",
+                    edit_memo_path(memo),
+                    class: "btn btn-sm btn-ghost btn-primary z-10" %>
+
+              <%= link_to "削除",
+                    memo_path(memo),
+                    data: {
+                      turbo_method: :delete,
+                      turbo_confirm: "このメモを削除しますか？" },
+                    class: "btn btn-sm btn-ghost btn-error z-10" %>
+            </div>
+      </div>

--- a/app/views/memos/_memo_card.html.erb
+++ b/app/views/memos/_memo_card.html.erb
@@ -1,5 +1,5 @@
-<div class="bg-memo card shadow-md rounded-lg p-4 relative <%= "hover:-translate-y-1" if local_assigns[:show_link] %>">
-        <% if local_assigns[:show_link] %>
+<div class="bg-memo card shadow-md rounded-lg p-4 relative <%= "hover:-translate-y-1" if local_assigns.fetch(:show_link, nil) %>">
+        <% if local_assigns.fetch(:show_link, nil)%>
           <%= link_to memo_path(memo),
           class:"cursor-pointer group absolute inset-0",
           data:{turbo_frame: "_top"} do end%>

--- a/app/views/memos/_memo_card.html.erb
+++ b/app/views/memos/_memo_card.html.erb
@@ -1,6 +1,6 @@
-<div class="bg-memo card shadow-md rounded-lg p-4 relative <%= "hover:-translate-y-1" if local_assigns.fetch(:show_link, nil) %>">
-        <% if local_assigns.fetch(:show_link, nil)%>
-          <%= link_to memo_path(memo),
+<div class="bg-memo card shadow-md rounded-lg p-4  <%= " relative hover:-translate-y-1 " if local_assigns.fetch(:absolute_link, nil) %>">
+        <% if local_assigns.fetch(:absolute_link, nil)%>
+          <%= link_to absolute_link,
           class:"cursor-pointer group absolute inset-0",
           data:{turbo_frame: "_top"} do end%>
         <% end %>

--- a/app/views/memos/edit.html.erb
+++ b/app/views/memos/edit.html.erb
@@ -2,6 +2,12 @@
       メモ編集
     <% end %>
 
+    <div class="relative">
+    <%= link_to '← メモ詳細へ戻る',
+        memo_path(@memo),
+        class: 'btn btn-ghost btn-sm ' %>
+    </div>
+
   <div class="card bg-memo shadow">
     <div class="card-body">
 
@@ -29,8 +35,7 @@
         </div>
 
         <!-- ボタン -->
-        <div class="flex justify-between">
-          <%= link_to "一覧へ", memos_path, class: "btn btn-ghost" %>
+        <div class="flex justify-end">
 
           <div class="flex gap-2">
             <%= f.submit "更新する", class: "btn btn-primary" %>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -46,7 +46,7 @@
     <% @searched_memos.each do |memo| %>
         <!--メモ一つ一つ-->
 
-          <%= render "memo_card", memo: memo %>
+          <%= render "memo_card", memo: memo, show_link: true %>
 
     <% end %>
 

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -46,7 +46,7 @@
     <% @searched_memos.each do |memo| %>
         <!--メモ一つ一つ-->
 
-          <%= render "memo_card", memo: memo, show_link: true %>
+          <%= render "memo_card", memo: memo, absolute_link: memo_path(memo) %>
 
     <% end %>
 

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -1,7 +1,9 @@
     <% content_for :title do %>
       メモ一覧
     <% end %>
+
     <% if @memos.any? %>
+    <!--検索ボックス-->
       <div>
         <%= search_form_for @q do |f| %>
           <div class="flex gap-2 sm:flex-row flex-col">
@@ -33,29 +35,41 @@
         <%= link_to "未整理メモ", stale_memos_path, class: "btn btn-ghost btn-sm" %>
       </div>
     <% end %>
+<!--検索ボックス系ここまで-->
 
-  <% if @searched_memos.any? %>
 
-    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-      <% @searched_memos.each do |memo| %>
-        <div class="bg-memo card shadow-md rounded-lg p-4">
-          <div>
-            <h2 class="card-title">
-              <%= memo.display_title %>
-            </h2>
 
-            <div class="card-body">
-              <% if memo.body.present? %>
-                <p class="text-sm text-base-content/80 line-clamp-3">
-                  <%= memo.body %>
-                </p>
-              <% else %>
-                <p class="text-sm text-base-content/50 italic">
-                  本文はありません
-                </p>
-              <% end %>
+<!--メモ一覧-->
+<% if @searched_memos.any? %>
+
+  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <% @searched_memos.each do |memo| %>
+        <!--メモ一つ一つ-->
+      <div class="bg-memo card shadow-md rounded-lg p-4">
+
+          <%= link_to memo_path(memo),
+          class:"cursor-pointer bg-base-200 transition group",
+          data:{turbo_frame: "_top"} do %>
+            <!--メモの内容の領域-->
+            <div class="hover:bg-base-200">
+              <h2 class="card-title">
+              <!--無題に対応している-->
+                <%= memo.display_title %>
+              </h2>
+
+              <div class="card-body">
+                <% if memo.body.present? %>
+                  <p class="text-sm text-base-content/80 line-clamp-3">
+                    <%= memo.body %>
+                  </p>
+                <% else %>
+                  <p class="text-sm text-base-content/50 italic">
+                    本文はありません
+                  </p>
+                <% end %>
+              </div>
             </div>
-
+            <!--メモのボタン等の領域-->
             <div class="card-actions justify-end mt-4">
               <%= link_to "詳細",
                     memo_path(memo),
@@ -72,31 +86,39 @@
                       turbo_confirm: "このメモを削除しますか？" },
                     class: "btn btn-sm btn-ghost btn-error" %>
             </div>
-          </div>
-        </div>
-      <% end %>
-    </div>
-      <div class="mt-12 flex flex-col gap-3">
-        <%= link_to "新しくメモを作成する",
-            new_memo_path,
-            class: "btn btn-primary" %>
+            
+            <% end %>
+
+
       </div>
 
-  <% elsif @memos.any? %>
-    <p class="text-gray-500">検索に一致するメモはありませんでした。</p>
-  <% else %>
-    <div class="text-center text-base-content/60">
 
-      <p class="mb-4">メモでは日々の生活の"うまく行く工夫"や"気づき"を書いておきます</p>
-      <p class="mb-2 text-xs">	
-      ex:朝水を飲むと頭がスッキリする</p>
-      <p class="mb-4 text-xs">	
-	    作業前に5分準備すると集中できる など</p>
-      <p class="mb-4">そのメモをもとにマイルールを作ります</p>
-      <p class="mb-4">まだメモがありません</p>
-      <%= link_to "最初のメモを作成する",
-            new_memo_path,
-            class: "btn btn-primary " %>
-    </div>
-  <% end %>
+    <% end %>
+
+  </div>
+
+  <div class="mt-12 flex flex-col gap-3">
+    <%= link_to "新しくメモを作成する",
+        new_memo_path,
+        class: "btn btn-primary" %>
+  </div>
+
+<!--if @searched_memos.any?ここまで-->
+<% elsif @memos.any? %>
+  <p class="text-gray-500">検索に一致するメモはありませんでした。</p>
+<% else %>
+  <div class="text-center text-base-content/60">
+
+    <p class="mb-4">メモでは日々の生活の"うまく行く工夫"や"気づき"を書いておきます</p>
+    <p class="mb-2 text-xs">	
+    ex:朝水を飲むと頭がスッキリする</p>
+    <p class="mb-4 text-xs">	
+    作業前に5分準備すると集中できる など</p>
+    <p class="mb-4">そのメモをもとにマイルールを作ります</p>
+    <p class="mb-4">まだメモがありません</p>
+    <%= link_to "最初のメモを作成する",
+          new_memo_path,
+          class: "btn btn-primary " %>
+  </div>
+<% end %>
 

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -69,6 +69,7 @@
                 <% end %>
               </div>
             </div>
+          <% end %>
             <!--メモのボタン等の領域-->
             <div class="card-actions justify-end mt-4">
               <%= link_to "詳細",
@@ -87,7 +88,7 @@
                     class: "btn btn-sm btn-ghost btn-error" %>
             </div>
             
-            <% end %>
+            
 
 
       </div>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -45,54 +45,8 @@
   <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
     <% @searched_memos.each do |memo| %>
         <!--メモ一つ一つ-->
-      <div class="bg-memo card shadow-md rounded-lg p-4">
 
-          <%= link_to memo_path(memo),
-          class:"cursor-pointer bg-base-200 transition group",
-          data:{turbo_frame: "_top"} do %>
-            <!--メモの内容の領域-->
-            <div class="hover:bg-base-200">
-              <h2 class="card-title">
-              <!--無題に対応している-->
-                <%= memo.display_title %>
-              </h2>
-
-              <div class="card-body">
-                <% if memo.body.present? %>
-                  <p class="text-sm text-base-content/80 line-clamp-3">
-                    <%= memo.body %>
-                  </p>
-                <% else %>
-                  <p class="text-sm text-base-content/50 italic">
-                    本文はありません
-                  </p>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-            <!--メモのボタン等の領域-->
-            <div class="card-actions justify-end mt-4">
-              <%= link_to "詳細",
-                    memo_path(memo),
-                    class: "btn btn-sm btn-ghost " %>
-
-              <%= link_to "編集",
-                    edit_memo_path(memo),
-                    class: "btn btn-sm btn-ghost btn-primary" %>
-
-              <%= link_to "削除",
-                    memo_path(memo),
-                    data: {
-                      turbo_method: :delete,
-                      turbo_confirm: "このメモを削除しますか？" },
-                    class: "btn btn-sm btn-ghost btn-error" %>
-            </div>
-            
-            
-
-
-      </div>
-
+          <%= render "memo_card", memo: memo %>
 
     <% end %>
 

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -10,6 +10,12 @@
   <p class="text-sm ">
     ルール作成フロー中（step1）
   </p>
+  <%else%>
+    <div class="relative">
+  <%= link_to '← メモ一覧へ戻る',
+      memos_path,
+      class: 'btn btn-ghost btn-sm ' %>
+  </div>
   <%end%>
 
 <div class="card bg-memo shadow">
@@ -57,9 +63,6 @@
         <% else %>
             <!--ルール作成のフローではない通常のmemo作成-->
           <div class="flex justify-end gap-3">
-            <%= link_to "キャンセル",
-                  memos_path,
-                  class: "btn btn-ghost" %>
             <%= f.submit "保存する",
                   class: "btn btn-primary" %>
           </div>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -66,13 +66,7 @@
       <!--メモに対応するルールのグリッド-->
         <% @memo.if_then_rules.each do |rule| %>
             <!--ルールのifとthenのグループ-->
-            <%= link_to if_then_rule_path(rule),
-            class:"bg-base-100 card shadow-md rounded-lg p-4  hover:-translate-y-1",
-            data:{turbo_frame: "_top"} do %>
-              <div class = "  p-4 rounded-t-lg ">
-                <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
-              </div>
-            <% end %>
+                <%= render "if_then_rules/cards/rule_card",  rule: rule, bg_class: "bg-base-100", show_status: false, absolute_link: if_then_rule_path( rule )  %>
         <% end %>
         <!--グリッドここまで-->
         </div>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -1,6 +1,7 @@
     <% content_for :title do %>
       <%= @memo.title.presence ||  "(無題)" %>
     <% end %>
+
 <% if @from_rule_flow %>
   <div class="relative">
   <%= link_to '← step1メモ選択へ戻る',
@@ -10,7 +11,14 @@
   <p class="text-sm ">
     ルール作成フロー中（step1）
   </p>
- <%end%>
+ <% else %>
+  <div class="relative">
+  <%= link_to '← メモ一覧へ戻る',
+      memos_path,
+      class: 'btn btn-ghost btn-sm ' %>
+  </div>
+
+  <% end %>
 
 <div class=" px-4 py-8 bg-memo ">
 
@@ -53,19 +61,25 @@
     <h2 class="font-bold text-lg ">
       ルール
     </h2>
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
-    <!--メモに対応するルールのグリッド-->
-      <% @memo.if_then_rules.each do |rule| %>
-          <!--ルールのifとthenのグループ-->
-          <%= link_to if_then_rule_path(rule),
-          class:"bg-base-100 card shadow-md rounded-lg p-4  hover:-translate-y-1",
-          data:{turbo_frame: "_top"} do %>
-            <div class = "  p-4 rounded-t-lg ">
-              <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
-            </div>
-          <% end %>
+    <% if @memo.if_then_rules.any? %>
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <!--メモに対応するルールのグリッド-->
+        <% @memo.if_then_rules.each do |rule| %>
+            <!--ルールのifとthenのグループ-->
+            <%= link_to if_then_rule_path(rule),
+            class:"bg-base-100 card shadow-md rounded-lg p-4  hover:-translate-y-1",
+            data:{turbo_frame: "_top"} do %>
+              <div class = "  p-4 rounded-t-lg ">
+                <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
+              </div>
+            <% end %>
+        <% end %>
+        <!--グリッドここまで-->
+        </div>
+      <% else %>
+        <p class="text-gray-500">
+          まだこのメモからのIf-Thenルールはありません。
+        </p>
       <% end %>
-  <!--グリッドここまで-->
-    </div>
   </div>
 <% end %>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -45,8 +45,27 @@
     </div>
   </div>
 </div>
+
+
+
 <% if !@from_rule_flow %>
   <div>
-  <%= link_to "一覧に戻る", memos_path, class: "btn btn-ghost btn-sm" %>
+    <h2 class="font-bold text-lg ">
+      ルール
+    </h2>
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+    <!--メモに対応するルールのグリッド-->
+      <% @memo.if_then_rules.each do |rule| %>
+          <!--ルールのifとthenのグループ-->
+          <%= link_to if_then_rule_path(rule),
+          class:"bg-base-100 card shadow-md rounded-lg p-4  hover:-translate-y-1",
+          data:{turbo_frame: "_top"} do %>
+            <div class = "  p-4 rounded-t-lg ">
+              <%= render "if_then_rules/cards/rule_sentence", rule: rule %>
+            </div>
+          <% end %>
+      <% end %>
+  <!--グリッドここまで-->
+    </div>
   </div>
 <% end %>

--- a/app/views/reflections/index.html.erb
+++ b/app/views/reflections/index.html.erb
@@ -31,11 +31,7 @@
             <div class="divider max-w-xl lg:max-w-full mx-auto px-2  text-gray-500"><%= date.strftime("%Y年%-m月%-d日") %></div>
             <ul class="space-y-2">
               <% reflections.each do |reflection| %>
-                <%= link_to if_then_rule_path(reflection.if_then_rule), class:"bg-base-100 card shadow-md rounded-lg p-4  hover:-translate-y-1" do %>
-                  <li>
-                    <%= render "if_then_rules/cards/rule_sentence", rule: reflection.if_then_rule %>
-                  </li>
-                <% end  %>
+                <%= render "if_then_rules/cards/rule_card",  rule: reflection.if_then_rule, bg_class: "bg-base-100", show_status: false, absolute_link: if_then_rule_path( reflection.if_then_rule)  %>
               <% end %>
             </ul>
             <% end %>

--- a/app/views/shared/_footer_logged_in.html.erb
+++ b/app/views/shared/_footer_logged_in.html.erb
@@ -1,4 +1,4 @@
-<footer class="dock dock-md bg-primary text-primary-content ">
+<footer class="dock dock-md bg-primary text-primary-content z-100">
   <%= link_to  dash_boards_path, class: "#{ 'dock-active' if controller_name == 'dash_boards' }" do %>
   <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e3e3e3"><path d="M240-200h120v-240h240v240h120v-360L480-740 240-560v360Zm-80 80v-480l320-240 320 240v480H520v-240h-80v240H160Zm320-350Z"/></svg>
   <span class="dock-label ">ダッシュボード</span>


### PR DESCRIPTION

## 概要
メモの詳細画面にルールの情報を入れて充実させる
ルールのカードのリファクタリング

Close #254 

## 実装内容
### 予定していた作業
- [x]  メモの詳細画面から対応するルールの一覧を見られるようにする
    - [x]  それぞれにはリンクを付与する

- [x]  メモの一覧にてタイトル(あるいはカード)をクリックすると詳細になるようにする
    - [x]  詳細ボタン不要ということで削除
- [x]  現在の中途半端な一覧に戻るボタンは削除する
    - [x]  代わりにルールの新規作成フローにあるような戻るボタンを付与する
    - [x]  メモの編集などでも同様に調整
    - [x]  ルールの一覧においても同様に戻るボタンを付与する?



### 予定外だが実施した作業
- [x]  ルールとメモをabsoluteリンクにより、カード全体クリックでの詳細選択にできるらしい。
- [x]  rule_cardの調整
    - [x]  sentenceを除きその内容は出しわけできるようにする
        - [x]  曜日のtrue|false
        - [x]  statusのtrue|false
    - [x]  yield方式の廃止
- [x] ただのメモ作成画面から勝手にルール作成フローに入っている問題

## 動作確認

詳細画面に対応するルールをいれて遷移しやすく
<img width="653" height="695" alt="image" src="https://github.com/user-attachments/assets/22c1fe86-9fa5-43a0-8fbf-5fb34fe3048f" />



## 備考


この構造によりカード全体のクリックができる状態かつ、
個別のカードのボタンも機能する状態にできる。

特にaタグ同士では階層構造を持てないので,親の兄弟要素のカード全面用の透明なaタグを準備しつつ、カードの中の他のボタンはz軸を手前にすることで押せるようにする。というのが肝。
```
card (relative)
│
├ a.absolute inset-0   ← カード全面
│
├ card-body
│
└ card-actions (z-10)  ← 上に出る
```

