### PR TITLE
Fix/step UI map

### DIFF
--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -76,7 +76,6 @@ class IfThenRule < ApplicationRecord
     return if_condition if limit.nil?
 
     if_condition.truncate(limit)
-
   end
 
   def display_then(limit: 30)
@@ -84,7 +83,6 @@ class IfThenRule < ApplicationRecord
     return then_action if limit.nil?
 
     then_action.truncate(limit)
-
   end
 private
 

--- a/app/models/if_then_rule.rb
+++ b/app/models/if_then_rule.rb
@@ -70,6 +70,22 @@ class IfThenRule < ApplicationRecord
     { date: date, label: :later }
   end
 
+
+  def display_if(limit: 30)
+    return "（空欄）" if if_condition.blank?
+    return if_condition if limit.nil?
+
+    if_condition.truncate(limit)
+
+  end
+
+  def display_then(limit: 30)
+    return "（空欄）" if then_action.blank?
+    return then_action if limit.nil?
+
+    then_action.truncate(limit)
+
+  end
 private
 
   def next_scheduled_date

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -24,7 +24,7 @@ class Memo < ApplicationRecord
 
   #値がない場合に対応したメモの本文を表示するメソッド limitがnilなら全文
   def display_body(limit: 30)
-    return "（内容なし）" if body.blank?
+    return "（本文がありません）" if body.blank?
     return body if limit.nil?
 
     body.truncate(limit)

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -17,14 +17,23 @@ class Memo < ApplicationRecord
   def self.ransackable_associations(auth_object = nil)
     [ "if_then_rules" ]
   end
-
+#値がない場合に対応したタイトル表示のメソッド
   def display_title
     title.present? ? title.truncate(20) : "（無題）"
   end
 
+  #値がない場合に対応したメモの本文を表示するメソッド limitがnilなら全文
+  def display_body(limit: 30)
+    return "（内容なし）" if body.blank?
+    return body if limit.nil?
+
+    body.truncate(limit)
+  end
+# セレクトのフォームフィールドで使用
   def display_for_select
     title_text = title.present? ? title.truncate(20) : "（無題）"
     body_text = body.presence&.truncate(10)
     "#{title_text} - #{body_text}"
   end
+
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -17,23 +17,22 @@ class Memo < ApplicationRecord
   def self.ransackable_associations(auth_object = nil)
     [ "if_then_rules" ]
   end
-#値がない場合に対応したタイトル表示のメソッド
+  # 値がない場合に対応したタイトル表示のメソッド
   def display_title
     title.present? ? title.truncate(20) : "（無題）"
   end
 
-  #値がない場合に対応したメモの本文を表示するメソッド limitがnilなら全文
+  # 値がない場合に対応したメモの本文を表示するメソッド limitがnilなら全文
   def display_body(limit: 30)
     return "（本文がありません）" if body.blank?
     return body if limit.nil?
 
     body.truncate(limit)
   end
-# セレクトのフォームフィールドで使用
+  # セレクトのフォームフィールドで使用
   def display_for_select
     title_text = title.present? ? title.truncate(20) : "（無題）"
     body_text = body.presence&.truncate(10)
     "#{title_text} - #{body_text}"
   end
-
 end

--- a/app/views/if_then_rules/_flow_navigation.html.erb
+++ b/app/views/if_then_rules/_flow_navigation.html.erb
@@ -1,4 +1,9 @@
 <ul class="steps">
+
+  <%  if step==1.5 %>
+  <li  class="step <%= "step-primary" if step >= 1 %> ">1.メモの作成</li>
+  <%  else  %>
   <li class="step <%= "step-primary" if step >= 1 %> ">1.メモ選択</li>
-  <li class="step <%= "step-primary" if step >= 2 %>">2.if-thenでルールの作成</li>
+  <% end %>
+  <li data-content="2" class="step <%= "step-primary" if step >= 2 %>">2.if-thenでルールの作成</li>
 </ul>

--- a/app/views/if_then_rules/_form.html.erb
+++ b/app/views/if_then_rules/_form.html.erb
@@ -132,12 +132,12 @@
     <% if @memo %>
     <p class="text-xs text-gray-400 mb-1">現在のメモ</p>
       <div class="bg-memo p-3 rounded text-sm max-w-xl lg:max-w-full mx-auto min-h-32">
-        <%= @memo.title %>
-        <%= @memo.body %>
+        <%= @memo.display_title %>
+        <%= @memo.display_body %>
       </div>
     <% else %>
-      <p class="text-xs text-gray-400">
-        元メモなし
+      <p class="text-[11px] text-gray-400 mt-1">
+      元のメモがありません
       </p>
     <% end %>
 </div>

--- a/app/views/if_then_rules/cards/_rule_actions_dashboard.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_dashboard.html.erb
@@ -19,7 +19,7 @@
     <div class="flex justify-end ">
     <%= link_to "編集",
       edit_if_then_rule_path(rule),
-      class: "btn btn-ghost btn-sm text-xs z-10",
+      class: "btn btn-ghost btn-sm btn-primary btn-sm text-xs z-10",
       data: { turbo_frame: "_top" }
     %>
   </div>

--- a/app/views/if_then_rules/cards/_rule_actions_index.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_index.html.erb
@@ -12,7 +12,7 @@
       <% end %>
     </div>
       <!--ボタン集-->
-      <div class="card-actions justify-end mt-4">
+      <div class="card-actions justify-center mt-4">
 
         <%= link_to "編集",
                     edit_if_then_rule_path(rule),

--- a/app/views/if_then_rules/cards/_rule_actions_show.html.erb
+++ b/app/views/if_then_rules/cards/_rule_actions_show.html.erb
@@ -1,15 +1,15 @@
 <div>
       <!--ボタン集-->
-      <div class="card-actions justify-end mt-4">
+      <div class="card-actions justify-center mt-4">
         <%= link_to "編集",
                     edit_if_then_rule_path(rule),
-                    class: "btn btn-ghost btn-sm btn-primary z-10" %>
+                    class: "btn btn-ghost btn-primary z-10" %>
         <%= link_to "削除",
           if_then_rule_path(rule),
           data: {
                       turbo_method: :delete,
                       turbo_confirm: "このルールを削除しますか？" },
-            class: "btn btn-ghost btn-error btn-sm z-10"
+            class: "btn btn-ghost btn-error  z-10"
         %>
       </div>
 </div>

--- a/app/views/if_then_rules/cards/_rule_sentence.html.erb
+++ b/app/views/if_then_rules/cards/_rule_sentence.html.erb
@@ -2,12 +2,12 @@
   もし
 </p>
 <p class="text-md bg-blue-100 rounded px-2 py-1 text-primary group-hover:bg-base-200">
-  <%= rule.if_condition %>
+  <%= rule.display_if %>
 </p>
 
 <p class="text-xs font-medium text-secondary text-left group-hover:bg-base-200">
   その時は
 </p>
 <p class="text-lg font-semibold text-primary bg-green-100 rounded px-2 py-1 group-hover:bg-base-200">
-  <%= rule.then_action %>
+  <%= rule.display_then %>
 </p>

--- a/app/views/if_then_rules/flows/step1.html.erb
+++ b/app/views/if_then_rules/flows/step1.html.erb
@@ -17,12 +17,12 @@
   <div class="card bg-memo shadow-sm ">
     <div class="card-body">
       <h2 class="card-title text-base">
-        <%= memo.title %>
+        <%= memo.display_title %>
       </h2>
 
       <% if memo.body.present? %>
         <p class="text-sm text-gray-500 line-clamp-3">
-          <%= memo.body %>
+          <%= memo.display_body %>
         </p>
       <% end %>
 

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -26,7 +26,7 @@
   <!--集計のグリッドここまで-->
     </div>
   </div>
-
+  <div class="divider max-w-xl lg:max-w-full mx-auto px-2"></div>
   <!--ルールの元になったメモ-->
   <div>
     <h2 class="font-bold text-lg ">

--- a/app/views/if_then_rules/show.html.erb
+++ b/app/views/if_then_rules/show.html.erb
@@ -33,18 +33,9 @@
     元になったメモ
     </h2>
     <% if @memo.present? %>
-      <%= link_to memo_path(@memo),
-          class:"cursor-pointer hover:-translate-y-1 transition group",
-          data:{turbo_frame: "_top"} do %>
-        <div  class="bg-memo card rounded-lg shadow-sm hover:-translate-y-1 min-h-32">
-          <p class="text-[11px] text-gray-400 mt-1">
-            <%= @memo.title.presence || "（無題）" %>
-          </p>
-          <p class="text-[11px] text-gray-400 mt-1">
-            <%= @memo.body || "" %>
-          </p>
-        </div>
-      <% end %>
+    <div class="max-w-xl  mx-auto">
+      <%= render "memos/memo_card", memo: @memo, absolute_link: memo_path(@memo)%>
+    </div>
     <% else %>
       <p class="text-[11px] text-gray-400 mt-1">
         元のメモがありません

--- a/app/views/memos/_memo_card.html.erb
+++ b/app/views/memos/_memo_card.html.erb
@@ -55,14 +55,14 @@
                   <div class="flex gap-4">
                     <%= link_to "編集",
                                 edit_memo_path(@memo),
-                                class: "btn btn-outline btn-primary" %>
+                                class: "btn  btn-primary btn-ghost" %>
 
                     <%= link_to "削除",
                                   memo_path(@memo),
                                   data: {
                                     turbo_method: :delete,
                                     turbo_confirm: "このメモを削除しますか？" },
-                                  class: "btn btn-outline btn-error" %>
+                                  class: "btn  btn-error btn-ghost" %>
                   </div>
                 <!-- マイルール化ボタン -->
                 <div>

--- a/app/views/memos/_memo_card.html.erb
+++ b/app/views/memos/_memo_card.html.erb
@@ -26,9 +26,6 @@
 
             <!--メモのボタン等の領域-->
             <div class="card-actions justify-end mt-4 ">
-              <%= link_to "詳細",
-                    memo_path(memo),
-                    class: "btn btn-sm btn-ghost z-10" %>
 
               <%= link_to "編集",
                     edit_memo_path(memo),

--- a/app/views/memos/_memo_card.html.erb
+++ b/app/views/memos/_memo_card.html.erb
@@ -14,17 +14,20 @@
               <div class="card-body">
                 <% if memo.body.present? %>
                   <p class="text-sm text-base-content/80 line-clamp-3">
-                    <%= memo.body %>
+                    <%= memo.display_body %>
                   </p>
                 <% else %>
+                  <!--本文がない旨の表示だが一応見た目を変える-->
                   <p class="text-sm text-base-content/50 italic">
-                    本文はありません
+                    <%= memo.display_body %>
                   </p>
                 <% end %>
               </div>
             </div>
 
             <!--メモのボタン等の領域-->
+            <div class="flex flex-col gap-6 items-center ">
+            <% if local_assigns.fetch(:card_actions, false) == :index%>
             <div class="card-actions justify-end mt-4 ">
 
               <%= link_to "編集",
@@ -38,4 +41,36 @@
                       turbo_confirm: "このメモを削除しますか？" },
                     class: "btn btn-sm btn-ghost btn-error z-10" %>
             </div>
+            <% elsif local_assigns.fetch(:card_actions, false) == :show_on_flow%>
+            <div class="flex flex-col gap-6 items-center ">
+              <!-- マイルール化ボタン -->
+              <div>
+                <%= link_to "このメモで新しいマイルールを作る",
+                              new_if_then_rule_path(memo_id: @memo.id) ,
+                              class: "btn btn-primary w-full" %>
+              </div>
+            </div>
+            <% elsif local_assigns.fetch(:card_actions, false) == :show %>
+                  <!-- 編集・削除 -->
+                  <div class="flex gap-4">
+                    <%= link_to "編集",
+                                edit_memo_path(@memo),
+                                class: "btn btn-outline btn-primary" %>
+
+                    <%= link_to "削除",
+                                  memo_path(@memo),
+                                  data: {
+                                    turbo_method: :delete,
+                                    turbo_confirm: "このメモを削除しますか？" },
+                                  class: "btn btn-outline btn-error" %>
+                  </div>
+                <!-- マイルール化ボタン -->
+                <div>
+                  <%= link_to "このメモで新しいマイルールを作る",
+                                new_if_then_rule_path(memo_id: @memo.id) ,
+                                class: "btn btn-primary w-full" %>
+                </div>
+              </div>
+              <% end %>
+              </div>
       </div>

--- a/app/views/memos/_memo_form.html.erb
+++ b/app/views/memos/_memo_form.html.erb
@@ -1,0 +1,40 @@
+<%= form_with model: memo, url: url, method: method, local: true do |f| %>
+  <%= f.hidden_field :from, value: "rule_flow" if local_assigns.fetch(:on_rule_flow, false)%>
+  <div class="card bg-memo shadow">
+    <div class="card-body">
+      <!-- タイトル -->
+      <div class="form-control mb-4">
+        <%= f.label :title, "タイトル", class: "label" %>
+        <%= f.text_field :title,
+              class: "input input-bordered w-full",
+              placeholder: "タイトル" %>
+
+        <% if memo.errors[:title].any? %>
+          <p class="text-error text-sm mt-1">
+            <%= memo.errors[:title].first %>
+          </p>
+        <% end %>
+      </div>
+
+      <!-- 本文 -->
+      <div class="form-control mb-6">
+        <%= f.label :body, "内容", class: "label" %>
+        <%= f.text_area :body,
+              rows: 6,
+              class: "textarea textarea-bordered w-full",
+              placeholder: "目標やこうすると良いことがあるという工夫などを自由に書いてください これは後で'マイルール'を作るきっかけとして使います" %>
+        <% if memo.errors[:body].any? %>
+          <p class="text-error text-sm mt-1">
+            <%= memo.errors[:body].first %>
+          </p>
+        <% end %>
+      </div>
+
+    </div>
+  </div>
+  <!-- ボタン -->
+  <div class="pt-4">
+    <%= f.submit "保存する", class: "btn btn-primary w-full" %>
+  </div>
+
+  <% end %>

--- a/app/views/memos/edit.html.erb
+++ b/app/views/memos/edit.html.erb
@@ -10,35 +10,4 @@
 
     
     
-    <%= form_with model: @memo, local: true do |f| %>
-      <div class="card bg-memo shadow">
-        <div class="card-body">
-          <!-- タイトル -->
-          <div class="form-control mb-4">
-            <%= f.label :title, "タイトル", class: "label" %>
-            <%= f.text_field :title,
-                  class: "input input-bordered w-full" %>
-
-            <% if @memo.errors[:title].any? %>
-              <p class="text-error text-sm mt-1">
-                <%= @memo.errors[:title].first %>
-              </p>
-            <% end %>
-          </div>
-
-          <!-- 本文 -->
-          <div class="form-control mb-6">
-            <%= f.label :body, "内容", class: "label" %>
-            <%= f.text_area :body,
-                  rows: 6,
-                  class: "textarea textarea-bordered w-full" %>
-          </div>
-
-        </div>
-      </div>
-      <!-- ボタン -->
-      <div class="pt-4">
-        <%= f.submit "更新する", class: "btn btn-primary w-full" %>
-      </div>
-
-      <% end %>
+<%= render "memo_form", memo: @memo, url: memo_path(@memo), method: :patch %>

--- a/app/views/memos/edit.html.erb
+++ b/app/views/memos/edit.html.erb
@@ -8,39 +8,37 @@
         class: 'btn btn-ghost btn-sm ' %>
     </div>
 
-  <div class="card bg-memo shadow">
-    <div class="card-body">
+    
+    
+    <%= form_with model: @memo, local: true do |f| %>
+      <div class="card bg-memo shadow">
+        <div class="card-body">
+          <!-- タイトル -->
+          <div class="form-control mb-4">
+            <%= f.label :title, "タイトル", class: "label" %>
+            <%= f.text_field :title,
+                  class: "input input-bordered w-full" %>
 
-
-      <%= form_with model: @memo, local: true do |f| %>
-        <!-- タイトル -->
-        <div class="form-control mb-4">
-          <%= f.label :title, "タイトル", class: "label" %>
-          <%= f.text_field :title,
-                class: "input input-bordered w-full" %>
-
-          <% if @memo.errors[:title].any? %>
-            <p class="text-error text-sm mt-1">
-              <%= @memo.errors[:title].first %>
-            </p>
-          <% end %>
-        </div>
-
-        <!-- 本文 -->
-        <div class="form-control mb-6">
-          <%= f.label :body, "内容", class: "label" %>
-          <%= f.text_area :body,
-                rows: 6,
-                class: "textarea textarea-bordered w-full" %>
-        </div>
-
-        <!-- ボタン -->
-        <div class="flex justify-end">
-
-          <div class="flex gap-2">
-            <%= f.submit "更新する", class: "btn btn-primary" %>
+            <% if @memo.errors[:title].any? %>
+              <p class="text-error text-sm mt-1">
+                <%= @memo.errors[:title].first %>
+              </p>
+            <% end %>
           </div>
+
+          <!-- 本文 -->
+          <div class="form-control mb-6">
+            <%= f.label :body, "内容", class: "label" %>
+            <%= f.text_area :body,
+                  rows: 6,
+                  class: "textarea textarea-bordered w-full" %>
+          </div>
+
         </div>
+      </div>
+      <!-- ボタン -->
+      <div class="pt-4">
+        <%= f.submit "更新する", class: "btn btn-primary w-full" %>
+      </div>
+
       <% end %>
-    </div>
-  </div>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -46,7 +46,7 @@
     <% @searched_memos.each do |memo| %>
         <!--メモ一つ一つ-->
 
-          <%= render "memo_card", memo: memo, absolute_link: memo_path(memo) %>
+          <%= render "memo_card", memo: memo, absolute_link: memo_path(memo), card_actions: :index %>
 
     <% end %>
 

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -19,58 +19,15 @@
   </div>
   <%end%>
 
-<div class="card bg-memo shadow">
-  <div class="card-body">
-    <%= form_with model: @memo, local: true do |f| %>
-      <!-- タイトル -->
-      <div class="form-control mb-4">
-        <%= f.label :title, "タイトル", class: "label font-semibold" %>
-        <%= f.text_field :title,
-              class: "input input-bordered w-full",
-              placeholder: "タイトル" %>
-
-        <% if @memo.errors[:title].any? %>
-          <p class="text-error text-sm mt-1">
-            <%= @memo.errors[:title].first %>
-          </p>
-        <% end %>
-      </div>
-
-      <!-- 本文 -->
-      <div class="form-control mb-6">
-        <%= f.label :body, "メモ内容", class: "label font-semibold" %>
-        <%= f.text_area :body,
-              rows: 6,
-              class: "textarea textarea-bordered w-full",
-              placeholder: "目標やこうすると良いことがあるという工夫などを自由に書いてください これは後で'マイルール'を作るきっかけとして使います" %>
-
-        <% if @memo.errors[:body].any? %>
-          <p class="text-error text-sm mt-1">
-            <%= @memo.errors[:body].first %>
-          </p>
-        <% end %>
-      </div>
-
-
 
       <!-- ボタン -->
         <% if @from_rule_flow %>
           <!--ルール作成のフローの場合-->
-          <%= f.hidden_field :from, value: "rule_flow" %>
-          <div class="flex justify-end gap-3">
-            <%= f.submit "保存する",
-                  class: "btn btn-primary" %>
-          </div>
-        <% else %>
-            <!--ルール作成のフローではない通常のmemo作成-->
-          <div class="flex justify-end gap-3">
-            <%= f.submit "保存する",
-                  class: "btn btn-primary" %>
-          </div>
+          <%= render "memo_form", memo: @memo, url: memos_path, method: :post, on_rule_flow: true  %>
+
+            <% else %>
+            <%= render "memo_form", memo: @memo, url: memos_path, method: :post %>
 
         <% end %>
 
 
-    <% end %>
-  </div>
-</div>

--- a/app/views/memos/new.html.erb
+++ b/app/views/memos/new.html.erb
@@ -6,7 +6,8 @@
   <%= link_to '← step1メモ選択へ戻る',
       step1_if_then_rules_flow_path,
       class: 'btn btn-ghost btn-sm ' %>
-</div>
+  </div>
+  <%= render "if_then_rules/flow_navigation", step: 1.5 %>
   <p class="text-sm ">
     ルール作成フロー中（step1）
   </p>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -8,6 +8,7 @@
       step1_if_then_rules_flow_path,
       class: 'btn btn-ghost btn-sm ' %>
 </div>
+  <%= render "if_then_rules/flow_navigation", step: 1.5 %>
   <p class="text-sm ">
     ルール作成フロー中（step1）
   </p>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -57,6 +57,8 @@
 
 
 
+
+<div class="divider max-w-xl lg:max-w-full mx-auto px-2"></div>
 <% if !@from_rule_flow %>
   <div>
     <h2 class="font-bold text-lg ">

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -12,55 +12,27 @@
   <p class="text-sm ">
     ルール作成フロー中（step1）
   </p>
- <% else %>
+<% else %>
   <div class="relative">
   <%= link_to '← メモ一覧へ戻る',
       memos_path,
       class: 'btn btn-ghost btn-sm ' %>
   </div>
+<% end %>
 
+
+<!--メモの表示-->
+  <% if @from_rule_flow %>
+    <%= render "memo_card", memo: @memo, card_actions: :show_on_flow%>
+    <% else %>
+    <%= render "memo_card", memo: @memo, card_actions: :show%>
   <% end %>
-
-<div class=" px-4 py-8 bg-memo ">
-
-
-  <!-- 本文 -->
-  <div class="prose max-w-none mb-1">
-    <%= simple_format(@memo.body) %>
-  </div>
-
-  <!-- 操作ボタン群 -->
-  <div class="flex flex-col gap-6 items-center ">
-    <% if !@from_rule_flow %>
-      <!-- 編集・削除 -->
-      <div class="flex gap-4">
-        <%= link_to "編集",
-                    edit_memo_path(@memo),
-                    class: "btn btn-outline btn-primary" %>
-
-        <%= link_to "削除",
-                      memo_path(@memo),
-                      data: {
-                        turbo_method: :delete,
-                        turbo_confirm: "このメモを削除しますか？" },
-                      class: "btn btn-outline btn-error" %>
-      </div>
-    <% end %>
-    <!-- マイルール化ボタン -->
-    <div>
-      <%= link_to "このメモで新しいマイルールを作る",
-                    new_if_then_rule_path(memo_id: @memo.id) ,
-                    class: "btn btn-primary w-full" %>
-    </div>
-  </div>
-</div>
-
 
 
 
 <div class="divider max-w-xl lg:max-w-full mx-auto px-2"></div>
 <% if !@from_rule_flow %>
-  <div>
+  <div class="max-w-xl lg:max-w-full mx-auto">
     <h2 class="font-bold text-lg ">
       ルール
     </h2>
@@ -74,7 +46,7 @@
         <!--グリッドここまで-->
         </div>
       <% else %>
-        <p class="text-gray-500">
+        <p class="text-[11px] text-gray-400 mt-1">
           まだこのメモからのIf-Thenルールはありません。
         </p>
       <% end %>

--- a/app/views/memos/stale.html.erb
+++ b/app/views/memos/stale.html.erb
@@ -1,6 +1,7 @@
     <% content_for :title do %>
       未整理メモ一覧
     <% end %>
+    <p class="mb-4">ルールに紐づかないままで、触れられていないメモが表示されます</p>
     <div>
         <%= link_to "通常のメモ一覧へ", memos_path, class: "btn btn-ghost btn-sm" %>
     </div>


### PR DESCRIPTION

## 概要
ルールの作成フローでメモをその場で作ることを選択した場合、
ルールのステップUIが表示されてなかったのを修正

また全体的に共通化して表示に統一感をつくる

Close #256 

## 実装内容
### 予定していた作業
- [x]  制御はクエリパラメータとして存在するのでUIをメモの新規作成時もある状態にする
    - [x]  所定のパーシャルをいれる
    
    
 - [x] 細かい表示に関する調整  
    - [x]  メモのカードのパーシャル化
    - [x]  不要になったメモの詳細ボタン削除
    - [x]  その他ボタンなど統一感の調整
    - [x]  無題の場合の表記を統一
    - [x]  memoのフォームのパーシャル化


## 動作確認
<img width="566" height="527" alt="image" src="https://github.com/user-attachments/assets/1a6ddc39-d8be-438f-8602-170951738990" />
<img width="544" height="385" alt="image" src="https://github.com/user-attachments/assets/c71dcbf1-7cda-41d4-b156-b8d47916d688" />
